### PR TITLE
Add support for ScaleQuestions

### DIFF
--- a/extension/constants.js
+++ b/extension/constants.js
@@ -23,7 +23,9 @@ constants.QuestionType = {
   DROPDOWN: 'dropdown',
 
   // Handled by the Scale class.
-  SCALE: 'scale',
+  HORIZ_SCALE: 'horizontalScale',
+  MULT_HORIZ_SCALE: 'multipleHorizontalScale',
+  VERTICAL_SCALE: 'verticalScale',
 
   // Handled by the Essay class.
   SHORT_STRING: 'shortString',

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -159,6 +159,39 @@ function addQuestions(parentNode) {
       'Please compare and contrast pina coladas and mimosas.',
       false);
   parentNode.appendChild(pinaColadasEssay.makeDOMTree());
+
+  var hungry = new ScaleQuestion(
+      constants.QuestionType.VERTICAL_SCALE,
+      'How hungry are you?',
+      false,
+      ['I want to eat my hands', '', 'Medium', '', 'I hate food'],
+      constants.Randomize.ALL);
+  parentNode.appendChild(hungry.makeDOMTree());
+
+  var pizza = new ScaleQuestion(
+      constants.QuestionType.VERTICAL_SCALE,
+      'How delicious is pizza?',
+      false,
+      ['The best', '', 'Medium', '', 'Still pretty good', 'Mmm'],
+      constants.Randomize.ANCHOR_LAST);
+  parentNode.appendChild(pizza.makeDOMTree());
+
+  var adrienne = new ScaleQuestion(
+      constants.QuestionType.HORIZ_SCALE,
+      'How awesome is Adrienne?',
+      false,
+      ['Super duper', '', 'Blazing', '', 'Fantastical'],
+      constants.Randomize.ALL);
+  parentNode.appendChild(adrienne.makeDOMTree());
+
+  var kittens = new ScaleQuestion(
+      constants.QuestionType.MULT_HORIZ_SCALE,
+      'Wine is delicious.',
+      false,
+      ['Agree', '', '', '', 'Disagree'],
+      constants.Randomize.ALL);
+  kittens.setAttributes(['Red wine', 'White wine', 'Champagne']);
+  parentNode.appendChild(kittens.makeDOMTree());
 }
 
 /**

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -179,7 +179,7 @@ function addQuestions(parentNode) {
   var adrienne = new ScaleQuestion(
       constants.QuestionType.HORIZ_SCALE,
       'How awesome is Adrienne?',
-      false,
+      true,
       ['Super duper', '', 'Blazing', '', 'Fantastical'],
       constants.Randomize.ALL);
   parentNode.appendChild(adrienne.makeDOMTree());

--- a/extension/surveys/survey-style.css
+++ b/extension/surveys/survey-style.css
@@ -12,6 +12,12 @@
     'chrome-extension://__MSG_@@extension_id__/open-sans/OpenSans-Bold.ttf');
 }
 
+@font-face {
+  font-family: 'OpenSansSemibold';
+  src: url(
+    'chrome-extension://__MSG_@@extension_id__/open-sans/OpenSans-Semibold.ttf');
+}
+
 .alert {
   color: #DB4437;
 }
@@ -28,6 +34,10 @@ body {
   width: 800px;
 }
 
+.clear-div {
+  clear: both;
+}
+
 .fieldset {
   background-color: #ECF3FE;
   border: none;
@@ -35,8 +45,27 @@ body {
   padding: 8px;
 }
 
+.first-rowlabel {
+  padding-top: 1.2em;
+}
+
 .hidden {
   display: none;
+}
+
+.horizontal-rowlabel {
+  float: left;
+  font-family: 'OpenSansSemibold';
+  padding-bottom: 5px;
+  padding-right: 20px;
+  width: 90px;
+}
+
+.horizontal-scale {
+  float: left;
+  padding-bottom: 5px;
+  text-align: center;
+  width: 100px;
 }
 
 .inner-centering {

--- a/extension/surveys/surveygenerator.js
+++ b/extension/surveys/surveygenerator.js
@@ -204,8 +204,10 @@ ScaleQuestion.prototype.makeSingleRow =
     }
     scaleElements.push(answer);
   }
-  if (reverse)
-    scaleElements = flipArray(scaleElements, this.randomize);
+  if (reverse) {
+    scaleElements = flipArray(
+        scaleElements, (this.randomize == constants.Randomize.ANCHOR_LAST));
+  }
   for (var i = 0; i < scaleElements.length; i++)
     container.appendChild(scaleElements[i]);
 
@@ -359,18 +361,17 @@ function coinToss() {
 }
 
 /**
- * Flip an array. Will anchor the last element for ANCHOR_LAST.
+ * Flip an array.
  * @param {Array.Object} arr The array to flip.
- * @param {string} randomType The type of randomization (constants.Randomize)
+ * @param {bool} anchorLast Whether to anchor the last element.
  * @returns {Array.Object} The flipped array.
  */
-function flipArray(arr, randomType) {
-  var end = randomType == constants.Randomize.ANCHOR_LAST ?
-            arr.length - 1 : arr.length;
+function flipArray(arr, anchorLast) {
+  var end = anchorLast ? arr.length - 1 : arr.length;
   var reverseArr = [];
   for (var i = end - 1; i >= 0; i--)
     reverseArr.push(arr[i]);
-  if (randomType == constants.Randomize.ANCHOR_LAST)
+  if (anchorLast)
     reverseArr.push(arr[arr.length - 1]);
   return reverseArr;
 }

--- a/extension/surveys/surveygenerator.js
+++ b/extension/surveys/surveygenerator.js
@@ -101,7 +101,7 @@ FixedQuestion.prototype.makeDOMTree = function() {
       if (this.randomize != constants.Randomize.NONE)
         answerChoices = knuthShuffle(answerChoices, this.randomize);
       for (var i = 0; i < answerChoices.length; i++)
-        container.appendChild(answerChoices[i])
+        container.appendChild(answerChoices[i]);
       break;
     case constants.QuestionType.DROPDOWN:
       var select = document.createElement('select');
@@ -127,14 +127,133 @@ FixedQuestion.prototype.makeDOMTree = function() {
 
 // SCALE
 
-// TODO(felt): Implement and document this.
-function ScaleQuestion(
-    questionType, question, required, direction, labels, randomize) {
+/**
+ * Represents scale questions. Currently supports HORIZONTAL_SCALE and
+ * VERTICAL_SCALE question types. Randomization simply flips the order to
+ * preserve the scale structure.
+ * @param {string} questionType Question presentation (constants.QuestionType).
+ * @param {string} question The question to be asked.
+ * @param {boolean} required Whether the question needs to be answered.
+ * @param {Array.string} scale The labels for each point on the scale.
+ * @param {String} randomize Type of randomization (constants.Randomize).
+ */
+function ScaleQuestion(questionType, question, required, scale, randomize) {
   Question.call(this, questionType, question, required);
+  this.scale = scale;
+  this.randomize = randomize;
+  this.attributes = [];
 }
 
 ScaleQuestion.prototype = Object.create(Question.prototype);
 ScaleQuestion.prototype.constructor = ScaleQuestion;
+
+/**
+ * For multiple horizontal scales, like this:
+ *    How are you feeling?
+ *    - Sad 1 2 3 4 5
+ *    - Happy 1 2 3 4 5
+ * Here the adjectives "Sad" and "Happy" are attributes. This must be set
+ * before makeDOMTree().
+ * @param {Array.string} attributes The attributes that the user is rating.
+ */
+ScaleQuestion.prototype.setAttributes = function(attributes) {
+  if (this.questionType != constants.QuestionType.MULT_HORIZ_SCALE)
+    throw new Error('Only set attributes for MULT_HORIZ_SCALE questions.');
+  this.attributes = attributes;
+};
+
+/**
+ * A helper method for makeDOMTree.
+ * @param {boolean} horizontal Whether it is a horizontal scale.
+ * @param {string} questionName The DOM-ready question name.
+ * @param {boolean} reverse Whether to flip the array.
+ * @param {boolean} showLabels If horizontal, whether to show the labels.
+ * @private
+ */
+ScaleQuestion.prototype.makeSingleRow =
+    function(horizontal, questionName, reverse, showLabels) {
+  var container = document.createElement('div');
+  var scaleElements = [];
+  for (var i = 0; i < this.scale.length; i++) {
+    var answer = document.createElement('div');
+    if (horizontal)
+      answer.classList.add('horizontal-scale');
+    var shrunkenAnswer = i + '-' + getDomNameFromValue(this.scale[i]);
+
+    var radio = document.createElement('input');
+    radio.setAttribute('id', shrunkenAnswer);
+    radio.setAttribute('name', questionName);
+    radio.setAttribute('type', 'radio');
+    radio.setAttribute('value', shrunkenAnswer);
+    if (this.required)
+      radio.setAttribute('required', this.required);
+
+    var label = document.createElement('label');
+    label.setAttribute('for', shrunkenAnswer);
+    label.textContent = this.scale[i];
+
+    if (horizontal) {
+      if (showLabels) {
+        answer.appendChild(label);
+        answer.appendChild(document.createElement('br'));
+      }
+      answer.appendChild(radio);
+    } else {
+      answer.appendChild(radio);
+      answer.appendChild(label);
+    }
+    scaleElements.push(answer);
+  }
+  if (reverse)
+    scaleElements = flipArray(scaleElements, this.randomize);
+  for (var i = 0; i < scaleElements.length; i++)
+    container.appendChild(scaleElements[i]);
+
+  if (horizontal) {
+    var clearDiv = document.createElement('div');
+    clearDiv.classList.add('clear-div');
+    container.appendChild(clearDiv);
+  }
+  return container;
+};
+
+/**
+ * Creates the DOM representation of a ScaleQuestion.
+ * @return {Object} The DOM node that contains the question.
+ */
+ScaleQuestion.prototype.makeDOMTree = function() {
+  var horizontal =
+      this.questionType == constants.QuestionType.HORIZ_SCALE ||
+      this.questionType == constants.QuestionType.MULT_HORIZ_SCALE;
+  var multi = this.questionType == constants.QuestionType.MULT_HORIZ_SCALE;
+  var container = document.createElement('div');
+  container.classList.add('fieldset');
+
+  var legend = document.createElement('legend');
+  legend.textContent = this.question;
+  container.appendChild(legend);
+
+  var reverse = this.randomize == constants.Randomize.NONE ? false : coinToss();
+  var shrunkenQuestion = getDomNameFromValue(this.question);
+  if (multi) {
+    for (var i = 0; i < this.attributes.length; i++) {
+      var floatScale = document.createElement('div');
+      floatScale.classList.add('horizontal-rowlabel');
+      if (i == 0)
+        floatScale.classList.add('first-rowlabel');
+      floatScale.innerText = this.attributes[i] + ':';
+      container.appendChild(floatScale);
+      var questionName =
+          getDomNameFromValue(this.attributes[i]) + shrunkenQuestion;
+      container.appendChild(
+          this.makeSingleRow(horizontal, questionName, reverse, (i == 0)));
+    }
+  } else {
+    container.appendChild(
+        this.makeSingleRow(horizontal, shrunkenQuestion, reverse, true));
+  }
+  return container;
+}
 
 // ESSAY
 
@@ -225,6 +344,33 @@ function knuthShuffle(arr, randomType) {
     arr[randomIndex] = swapTemp;
   }
   return arr;
+}
+
+/**
+ * A wrapper method for Math.random.
+ * @returns {boolean} Returns true half the time.
+ */
+function coinToss() {
+  if ((Math.random()) < 0.5)
+    return true;
+  return false;
+}
+
+/**
+ * Flip an array. Will anchor the last element for ANCHOR_LAST.
+ * @param {Array.Object} arr The array to flip.
+ * @param {string} randomType The type of randomization (constants.Randomize)
+ * @returns {Array.Object} The flipped array.
+ */
+function flipArray(arr, randomType) {
+  var end = randomType == constants.Randomize.ANCHOR_LAST ?
+            arr.length - 1 : arr.length;
+  var reverseArr = [];
+  for (var i = end - 1; i >= 0; i--)
+    reverseArr.push(arr[i]);
+  if (randomType == constants.Randomize.ANCHOR_LAST)
+    reverseArr.push(arr[arr.length - 1]);
+  return reverseArr;
 }
 
 /**

--- a/extension/surveys/surveygenerator.js
+++ b/extension/surveys/surveygenerator.js
@@ -225,7 +225,9 @@ ScaleQuestion.prototype.makeDOMTree = function() {
   var horizontal =
       this.questionType == constants.QuestionType.HORIZ_SCALE ||
       this.questionType == constants.QuestionType.MULT_HORIZ_SCALE;
-  var multi = this.questionType == constants.QuestionType.MULT_HORIZ_SCALE;
+  var multi =
+      (this.questionType == constants.QuestionType.MULT_HORIZ_SCALE) &&
+      this.attributes.length > 0;
   var container = document.createElement('div');
   container.classList.add('fieldset');
 
@@ -236,15 +238,17 @@ ScaleQuestion.prototype.makeDOMTree = function() {
   var reverse = this.randomize == constants.Randomize.NONE ? false : coinToss();
   var shrunkenQuestion = getDomNameFromValue(this.question);
   if (multi) {
-    for (var i = 0; i < this.attributes.length; i++) {
+    var shuffledAttributes =
+        knuthShuffle(this.attributes, constants.Randomize.ALL);
+    for (var i = 0; i < shuffledAttributes.length; i++) {
       var floatScale = document.createElement('div');
       floatScale.classList.add('horizontal-rowlabel');
       if (i == 0)
         floatScale.classList.add('first-rowlabel');
-      floatScale.innerText = this.attributes[i] + ':';
+      floatScale.innerText = shuffledAttributes[i] + ':';
       container.appendChild(floatScale);
       var questionName =
-          getDomNameFromValue(this.attributes[i]) + shrunkenQuestion;
+          getDomNameFromValue(shuffledAttributes[i]) + shrunkenQuestion;
       container.appendChild(
           this.makeSingleRow(horizontal, questionName, reverse, (i == 0)));
     }

--- a/extension/surveys/surveygenerator.js
+++ b/extension/surveys/surveygenerator.js
@@ -245,7 +245,7 @@ ScaleQuestion.prototype.makeDOMTree = function() {
       floatScale.classList.add('horizontal-rowlabel');
       if (i == 0)
         floatScale.classList.add('first-rowlabel');
-      floatScale.innerText = shuffledAttributes[i] + ':';
+      floatScale.textContent = shuffledAttributes[i] + ':';
       container.appendChild(floatScale);
       var questionName =
           getDomNameFromValue(shuffledAttributes[i]) + shrunkenQuestion;
@@ -355,9 +355,7 @@ function knuthShuffle(arr, randomType) {
  * @returns {boolean} Returns true half the time.
  */
 function coinToss() {
-  if ((Math.random()) < 0.5)
-    return true;
-  return false;
+  return (Math.random() < 0.5);
 }
 
 /**

--- a/extension/surveys/surveygenerator.js
+++ b/extension/surveys/surveygenerator.js
@@ -257,7 +257,7 @@ ScaleQuestion.prototype.makeDOMTree = function() {
         this.makeSingleRow(horizontal, shrunkenQuestion, reverse, true));
   }
   return container;
-}
+};
 
 // ESSAY
 


### PR DESCRIPTION
This adds support for scale questions, including:
- Randomize the direction of the scale, with support for an anchor
- Multiple rows (attributes) with the same scale
- Randomization goes the same direction for multiple attributes
- Shuffle the ordering of multiple rows

![screen shot 2014-10-15 at 7 00 14 am](https://cloud.githubusercontent.com/assets/4962198/4646554/511879f0-5474-11e4-9a4c-67cdc93e39eb.png)

Issue #17 
