### PR TITLE
Detect other types of events besides SSL

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -166,9 +166,21 @@ function loadSurvey(element, decision, timePromptShown, timePromptClicked) {
     case constants.EventType.SSL:
       surveyURL = surveyLocations.SSL;
       break;
-    case constants.EventType.UNKNOWN:
+    case constants.EventType.MALWARE:
+    case constants.EventType.PHISHING:
+    case constants.EventType.DOWNLOAD_MALICIOUS:
+    case constants.EventType.EXTENSION_INSTALL:
+      // TODO: Make surveys for each of these.
       surveyURL = surveyLocations.EXAMPLE;
-      console.log('Unknown event type: ' + element['name']);
+      break;
+    case constants.EventType.HARMFUL:
+    case constants.EventType.SB_OTHER:
+    case constants.EventType.DOWNLOAD_DANGEROUS:
+    case constants.EventType.DOWNLOAD_DANGER_PROMPT:
+      // Don't survey about these.
+      return;
+    case constants.EventType.UNKNOWN:
+      throw new Error('Unknown event type: ' + element['name']);
       break;
   }
   chrome.tabs.create(

--- a/extension/constants.js
+++ b/extension/constants.js
@@ -43,10 +43,21 @@ constants.Randomize = {
 // Handle "other" specially.
 constants.OTHER = 'Other: ';
 
-// The different types of event types.
+// The different types of events that trigger survey notifications.
 constants.EventType = {
-  UNKNOWN: 'unknown',
   SSL: 'ssl_interstitial',
+  MALWARE: 'safebrowsing_interstitial',
+  PHISHING: 'phishing_interstitial',
+  HARMFUL: 'harmful_interstitial',
+  SB_OTHER: 'safebrowsing_other',
+
+  DOWNLOAD_MALICIOUS: 'download_warning_malicious',
+  DOWNLOAD_DANGEROUS: 'download_warning_dangerous',
+  DOWNLOAD_DANGER_PROMPT: 'download_danger_prompt',
+
+  EXTENSION_INSTALL: 'extension_install_dialog',
+
+  UNKNOWN: 'unknown',
 };
 
 /**
@@ -57,9 +68,11 @@ constants.EventType = {
  * @returns {string} The matching EventType.
  */
 constants.FindEventType = function(str) {
-  var re = new RegExp('^' + constants.EventType.SSL);
-  if (str.match(re))
-    return constants.EventType.SSL;
+  for (var evt in constants.EventType) {
+    var re = new RegExp('^' + constants.EventType[evt]);
+    if (str.match(re))
+      return constants.EventType[evt];
+  }
   return constants.EventType.UNKNOWN;
 };
 


### PR DESCRIPTION
Adds checking for other types of events. For the moment, leaves them as opening the example survey.
