### PR TITLE
Uninstall extension after 120 days

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -23,7 +23,8 @@ cesp.NOTIFICATION_BUTTON = 'Take survey!';
 cesp.ICON_FILE = 'icon.png';
 cesp.NOTIFICATION_DEFAULT_TIMEOUT = 10;  // minutes
 cesp.NOTIFICATION_TAG = 'chromeSurvey';
-cesp.ALARM_NAME = 'notificationTimeout';
+cesp.NOTIFICATION_ALARM_NAME = 'notificationTimeout';
+cesp.UNINSTALL_ALARM_NAME = 'uninstallAlarm';
 
 // SETUP
 
@@ -104,7 +105,7 @@ chrome.runtime.onInstalled.addListener(setupState);
  */
 function clearNotifications(unused) {
   chrome.notifications.clear(cesp.NOTIFICATION_TAG, function(unused) {});
-  chrome.alarms.clearAll();
+  chrome.alarms.clear(cesp.NOTIFICATION_ALARM_NAME);
 }
 
 /**
@@ -137,7 +138,7 @@ function showSurveyNotification(element, decision) {
       opt,
       function(id) {
         chrome.alarms.create(
-            cesp.ALARM_NAME,
+            cesp.NOTIFICATION_ALARM_NAME,
             {delayInMinutes: cesp.NOTIFICATION_DEFAULT_TIMEOUT});
       });
   chrome.notifications.onClicked.addListener(clickHandler);

--- a/extension/background.js
+++ b/extension/background.js
@@ -50,9 +50,8 @@ function setupState(details) {
  * @param {Alarm} alarm The alarm object from the onAlarm event.
 */
 function handleUninstallAlarm(alarm) {
-  if (alarm.name === cesp.UNINSTALL_ALARM_NAME) {
+  if (alarm.name === cesp.UNINSTALL_ALARM_NAME)
     chrome.management.uninstallSelf();
-  }
 }
 chrome.alarms.onAlarm.addListener(handleUninstallAlarm);
 


### PR DESCRIPTION
- Added an alarm created during setup to uninstall the extension after 120 days.
- Added a listener for that alarm.
- Renamed the alarms to differentiate between the notification timeout alarm and the uninstall alarm.
- Added a check to clearNotifications to only run the body if it's the notification timeout alarm.
- Moved the onAlarm.addListener for the notification timeout next to clearNotification, where it's a little clearer.

This fixes issue #40 
