### PR TITLE
Throttle surveys shown per day

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -44,10 +44,13 @@ function setupState(details) {
     });
     // Automatically uninstall the extension after 120 days.
     chrome.alarms.create(cesp.UNINSTALL_ALARM_NAME, {delayInMinutes: 172800});
-    // Set the count of surveys shown to 0, and reset it each day.
+    // Set the count of surveys shown to 0, and reset it each day at midnight.
     chrome.storage.local.set({cesp.SURVEYS_SHOWN_TODAY: 0});
+    var midnight = new Date();
+    midnight.setHours(0, 0, 0, 0);
+    // midnight is the last midnight, so we set the alarm for one day from it.
     chrome.alarms.create(cesp.SURVEY_THROTTLE_RESET_ALARM,
-        {delayInMinutes: 5, periodInMinutes: 1440});
+        {when: midnight.getTime() + 86400000, periodInMinutes: 1440});
   }
 }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -25,6 +25,7 @@ cesp.ICON_FILE = 'icon.png';
 cesp.NOTIFICATION_DEFAULT_TIMEOUT = 10;  // minutes
 cesp.NOTIFICATION_TAG = 'chromeSurvey';
 cesp.ALARM_NAME = 'notificationTimeout';
+cesp.SURVEY_COUNT_RESET_ALARM_NAME = 'surveyCountReset';
 
 // SETUP
 
@@ -41,6 +42,17 @@ function setupState() {
   chrome.alarms.create(cesp.SURVEY_THROTTLE_RESET_ALARM,
       {delayInMinutes: 5, periodInMinutes: 1440});
 }
+
+/**
+ * Resets the count of surveys shown to 0.
+ * @param {Alarm} alarm The alarm object from the onAlarm event.
+ */
+function resetSurveyCount(alarm) {
+  if (alarm.name === cesp.SURVEY_THROTTLE_RESET_ALARM) {
+    chrome.storage.local.set({cesp.SURVEYS_SHOWN_TODAY: 0});
+  }
+}
+chrome.alarms.onAlarm.addListener(resetSurveyCount);
 
 /**
  * Retrieves the registration status from Local Storage.

--- a/extension/background.js
+++ b/extension/background.js
@@ -20,6 +20,7 @@ cesp.XHR_TIMEOUT = 4000;
 cesp.NOTIFICATION_TITLE = 'New Chrome survey available!';
 cesp.NOTIFICATION_BODY = 'Your feedback makes Chrome better.';
 cesp.NOTIFICATION_BUTTON = 'Take survey!';
+cesp.MAX_SURVEYS_PER_DAY = 10;  // TODO: Is this a sane number per day?
 cesp.ICON_FILE = 'icon.png';
 cesp.NOTIFICATION_DEFAULT_TIMEOUT = 10;  // minutes
 cesp.NOTIFICATION_TAG = 'chromeSurvey';


### PR DESCRIPTION
- Add a check to showSurveyNotification to only proceed if we're under some maximum number of surveys to show each day.
- Add an alarm to reset the count of surveys shown to 0 each day.

This fixes issue #31 
