### PR TITLE
Update consent form links

### DIFF
--- a/extension/consent.css
+++ b/extension/consent.css
@@ -1,0 +1,22 @@
+#consent-form-holder {
+  padding: 10px 0 10px 0;
+}
+
+#give-consent {
+  color: #4285F4;
+  font-size: 1.1em;
+  font-weight: bold;
+}
+
+html, body {
+  height: auto;
+  margin: 1em;
+}
+
+#no-consent {
+  color: #656565;
+}
+
+#uninstall {
+  color: #C53D32;
+}

--- a/extension/consent.html
+++ b/extension/consent.html
@@ -2,6 +2,7 @@
 <head>
 <title>Consent to Participate</title>
 <link rel="stylesheet" type="text/css" href="surveys/survey-style.css">
+<link rel="stylesheet" type="text/css" href="consent.css">
 <script src="constants.js"></script>
 <script src="surveys/surveygenerator.js"></script>
 <script src="consent.js"></script>
@@ -10,12 +11,14 @@
 <body>
   <div id="consent-text">
     <div class="centered inner-centering">
-      <h1>Informed consent for Safe Browsing Study</h1>
+      <h1>Google Chrome Web-Browsing Event Study</h1>
     </div>
 
     <div class="centered inner-centering alert-gentle hidden" id="top-blurb">
-      Thank you for your participation in our research study.<br> It is being
-      conducted by members of the Chrome team at Google Inc ("Google").
+      <b>Thank you for your participation in our research study.</b>
+      <br>
+      It is being conducted by members of the Chrome team at Google Inc
+      ("Google").
     </div>
 
     <div id="study-information" class="hidden centered">
@@ -72,14 +75,20 @@
     </div>
   </div>
 
-  <div id="consent-form-holder" class="hidden centered">
-    <form name="consent-form" id="consent-form"></form>
+  <div id="consent-form-holder" class="hidden centered inner-centering">
+    <a href="surveys/setup.html" id="give-consent" class="consent-link">I
+        acknowledge that I have read this informed consent and agree to the
+        terms</a>
+    <br>
+    <a href="#" id="no-consent" class="consent-link">No thanks, I prefer not to
+        participate</a>
   </div>
 
-  <div id="retract-consent" class="hidden alert centered">
+  <div id="retract-consent" class="hidden alert centered inner-centering">
     <p>You previously signed this consent form. If you no longer want to
-    participate, you should <a href="chrome://extensions">uninstall this
-    extension</a>.</p>
+    participate, you should <a
+    href="https://support.google.com/chrome/answer/113907?hl=en"
+    id="uninstall">uninstall</a> this extension.</p>
   </div>
 
 </body>

--- a/extension/consent.js
+++ b/extension/consent.js
@@ -67,7 +67,7 @@ function userRejectConsent(event) {
   console.log('Consent rejected');
   setConsentStorageValue(constants.CONSENT_REJECTED);
   $('consent-form-holder').classList.add('hidden');
-  setTimeout(chrome.management.uninstallSelf);
+  chrome.management.uninstallSelf;
 }
 
 /**

--- a/extension/consent.js
+++ b/extension/consent.js
@@ -67,7 +67,7 @@ function userRejectConsent(event) {
   console.log('Consent rejected');
   setConsentStorageValue(constants.CONSENT_REJECTED);
   $('consent-form-holder').classList.add('hidden');
-  chrome.management.uninstallSelf;
+  chrome.management.uninstallSelf();
 }
 
 /**

--- a/extension/consent.js
+++ b/extension/consent.js
@@ -4,8 +4,6 @@
 
 var consentForm = {};  // Namespace variable
 
-consentForm.UNINSTALL_TIME =  200;   // Milliseconds
-
 consentForm.status = constants.CONSENT_PENDING;
 
 /**
@@ -16,32 +14,6 @@ function setConsentStorageValue(newState) {
   var items = {};
   items[constants.CONSENT_KEY] = newState;
   chrome.storage.local.set(items);
-}
-
-/**
- * Adds the consent question at the bottom of the consent form. This form is
- * slightly custom: it doesn't actually have a question, and the JavaScript
- * in the form submit handler expects the "Yes" and "No" responses to be in a
- * certain order.
- * @param {Object} parentNode The DOM node to attach the question to
- */
-function addConsentForm(parentNode) {
-  var consentQuestion = new FixedQuestion(
-      constants.QuestionType.RADIO,
-      'consent',  // No question.
-      true,
-      [
-        // The "Yes" answer should come first.
-        'Yes, Adrienne is a rock star',
-        'No, please uninstall this extension'
-      ],
-      constants.Randomize.NONE);
-  // Remove the unneeded question label.
-  var domNode = consentQuestion.makeDOMTree();
-  var framesetDiv = domNode.childNodes[0];
-  var unneededLabel = framesetDiv.childNodes[0];
-  framesetDiv.removeChild(unneededLabel);
-  parentNode.appendChild(domNode);
 }
 
 /**
@@ -62,10 +34,8 @@ function setupConsentForm(savedState) {
     $('study-information').classList.remove('hidden');
     $('top-blurb').classList.remove('hidden');
     $('consent-form-holder').classList.remove('hidden');
-    addConsentForm($('consent-form'));
-    $('consent-form').appendChild(makeSubmitButtonDOM());
-    document.forms['consent-form'].addEventListener(
-        'submit', consentFormSubmitted);
+    $('give-consent').addEventListener('click', userGrantConsent);
+    $('no-consent').addEventListener('click', userRejectConsent)
   } else if (consentForm.status == constants.CONSENT_GRANTED) {
     // Show the consent form and the user's decision.
     $('study-information').classList.remove('hidden');
@@ -79,26 +49,25 @@ function setupConsentForm(savedState) {
 }
 
 /**
- * Handles the submission of the consent form.
- * @param {object} The submission button click event.
+ * Handles the user giving consent.
+ * @param {object} The link click event.
  */
-function consentFormSubmitted(event) {
+function userGrantConsent(event) {
+  console.log('Consent granted');
+  setConsentStorageValue(constants.CONSENT_GRANTED);
+  $('consent-form-holder').classList.add('hidden');
+}
+
+/**
+ * Handles the user withdrawing consent.
+ * @param {object} The link click event.
+ */
+function userRejectConsent(event) {
   event.preventDefault();
-  var consentRadio = document['consent-form']['consent'];
-  console.log('Consent form submitted: ' + consentRadio.value);
-  if (consentRadio.value.match(/^0/)) {  // YES
-    setConsentStorageValue(constants.CONSENT_GRANTED);
-    $('consent-form-holder').classList.add('hidden');
-    window.location.href = 'surveys/setup.html';
-  } else if (consentRadio.value.match(/^1/)) {  // NO
-    setConsentStorageValue(constants.CONSENT_REJECTED);
-    $('consent-form-holder').classList.add('hidden');
-    // It's unpleasant to close the window too fast after clicking the
-    // button. This adds a just-barely-perceptible delay.
-    setTimeout(chrome.management.uninstallSelf, consentForm.UNINSTALL_TIME);
-  } else {
-    $('set-value').classList.remove('hidden');
-  }
+  console.log('Consent rejected');
+  setConsentStorageValue(constants.CONSENT_REJECTED);
+  $('consent-form-holder').classList.add('hidden');
+  setTimeout(chrome.management.uninstallSelf);
 }
 
 /**


### PR DESCRIPTION
Rob asked if we could turn the consent form choices into links. This does that.
Also removes the extension uninstall delay since it wasn't useful anyway.

![screen shot 2014-10-19 at 8 50 33 am](https://cloud.githubusercontent.com/assets/4962198/4693745/6c87dcc4-57aa-11e4-84f6-c30c4a633b51.png)

(Part of Issue #7)
