### PR TITLE
Fix "required" checkboxes

### DIFF
--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -57,6 +57,13 @@ function FixedQuestion(
 FixedQuestion.prototype = Object.create(Question.prototype);
 FixedQuestion.prototype.constructor = FixedQuestion;
 
+function checkRequiredForm(questionName) {
+  var elems = document.getElementsByName(questionName);
+  for (var i = 0; i < elems.length; i++) {
+    elems[i].removeAttribute('required');
+  }
+}
+
 /**
  * Creates the DOM representation of a FixedQuestion question.
  * @return {object} The DOM node that contains the question.
@@ -82,7 +89,21 @@ FixedQuestion.prototype.makeDOMTree = function() {
         input.setAttribute('name', shrunkenQuestion);
         input.setAttribute('type', this.questionType);
         input.setAttribute('value', shrunkenAnswer);
-        input.setAttribute('required', this.required);
+        if (this.required) {
+          input.setAttribute('required', this.required);
+          if (this.questionType === constants.QuestionType.CHECKBOX) {
+            // By default, HTML5 requires *all* of the checkboxes to be checked
+            // for submission. Since we only want one of a group to be submitted
+            // submitted, remove the requirement once one is checked.
+            input.addEventListener('click', function removeRequired(unused) {
+              var elems = document.getElementsByName(shrunkenQuestion);
+              for (var i = 0; i < elems.length; i++) {
+                elems[i].removeAttribute('required');
+                elems[i].removeEventListener('click', removeRequired);
+              }
+            });
+          }
+        }
         answer.appendChild(input);
 
         var label = document.createElement('label');

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -57,13 +57,6 @@ function FixedQuestion(
 FixedQuestion.prototype = Object.create(Question.prototype);
 FixedQuestion.prototype.constructor = FixedQuestion;
 
-function checkRequiredForm(questionName) {
-  var elems = document.getElementsByName(questionName);
-  for (var i = 0; i < elems.length; i++) {
-    elems[i].removeAttribute('required');
-  }
-}
-
 /**
  * Creates the DOM representation of a FixedQuestion question.
  * @return {object} The DOM node that contains the question.

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -88,7 +88,7 @@ FixedQuestion.prototype.makeDOMTree = function() {
             // By default, HTML5 requires *all* of the checkboxes to be checked
             // for submission. Since we only want one of a group to be submitted
             // submitted, remove the requirement once one is checked.
-            input.addEventListener('click', function removeRequired(unused) {
+            answer.addEventListener('click', function removeRequired(unused) {
               var elems = document.getElementsByName(shrunkenQuestion);
               for (var i = 0; i < elems.length; i++) {
                 elems[i].removeAttribute('required');

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -86,9 +86,9 @@ FixedQuestion.prototype.makeDOMTree = function() {
           input.setAttribute('required', this.required);
           if (this.questionType === constants.QuestionType.CHECKBOX) {
             // By default, HTML5 requires *all* of the checkboxes to be checked
-            // for submission. Since we only want one of a group to be submitted
+            // for submission. Since we only want one of a group to be
             // submitted, remove the requirement once one is checked.
-            answer.addEventListener('click', function removeRequired(unused) {
+            input.addEventListener('change', function removeRequired(unused) {
               var elems = document.getElementsByName(shrunkenQuestion);
               for (var i = 0; i < elems.length; i++) {
                 elems[i].removeAttribute('required');


### PR DESCRIPTION
When you apply the HTML5 "required" attribute to checkboxes, it requires that the user check _all_ of the checkboxes instead of a single one of the group. This adds a hack so that only one has to be clicked.

This fixes issue #18.
