### PR TITLE
Kill zombie windows

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -10,7 +10,8 @@
 
 var cesp = {};  // namespace variable
 
-cesp.operatingSystem = "";
+cesp.operatingSystem = '';
+cesp.openTabIds = [];
 
 // Settings.
 cesp.SERVER_URL = 'https://chrome-experience-sampling.appspot.com';
@@ -292,7 +293,12 @@ function loadSurvey(element, decision, timePromptShown, timePromptClicked) {
     var openUrl = 'surveys/survey.html?js=' + surveyUrl + '&url=' + visitUrl;
     chrome.tabs.create(
         {'url': chrome.extension.getURL(openUrl)},
-        function() { console.log('Opened survey.'); });
+        function(tab) {
+          for (var i = 0; i < cesp.openTabIds.length; i++) {
+            chrome.tabs.remove(cesp.openTabIds[i]);
+          }
+          cesp.openTabIds = [ tab.id ];
+        });
   });
 }
 


### PR DESCRIPTION
As described in #52, we have a zombie window problem:
1. Open a survey from a notification
2. Close the survey without submitting a form
3. Open another survey from the notification
4. The old survey that you closed will re-open (!!!)

This adds a hack to re-close all of the zombies as soon as they reopen.
