### PR TITLE
Fix consent options to bottom of screen

### DIFF
--- a/extension/consent.css
+++ b/extension/consent.css
@@ -1,5 +1,5 @@
-#consent-form-holder {
-  padding: 10px 0 10px 0;
+.bottom-text {
+  padding: 30px 0 10px 0;
 }
 
 #give-consent {
@@ -10,11 +10,35 @@
 
 html, body {
   height: auto;
-  margin: 1em;
+  margin: 0.5em 1em 1em 1em;
 }
 
 #no-consent {
   color: #656565;
+}
+
+.scroll-constant {
+  bottom: 0;
+  height: 80px;
+  left: 0;
+  position: absolute;
+  right: 0;
+}
+
+.scroll-holder {
+  height: 100%;
+  position: relative;
+}
+
+.scroll-scroll {
+  bottom: 80px;
+  border-bottom: 1px solid #F2F2F2;
+  left: 30;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  position: absolute;
+  right: 30;
+  top: 0;
 }
 
 #uninstall {

--- a/extension/consent.html
+++ b/extension/consent.html
@@ -10,96 +10,101 @@
 </head>
 
 <body>
-  <div id="consent-text">
-    <div class="centered inner-centering">
-      <h1>Google Chrome Web-Browsing Event Study</h1>
+  <div class="scroll-holder">
+
+    <div id="consent-text" class="scroll-scroll">
+      <div class="centered inner-centering">
+        <h1>Chrome User Experience Surveys (CUES)</h1>
+      </div>
+
+      <div class="centered inner-centering alert-gentle hidden" id="top-blurb">
+        <b>Thank you for your participation in our research study.</b>
+        <br>
+        It is being conducted by members of the Chrome team at Google Inc
+        ("Google").
+      </div>
+
+      <div id="study-information" class="hidden centered">
+        <h3>Purpose of the study</h3>
+        <p>We are looking to better understand how people interpret and
+        interact with Chrome and the Web during certain infrequent events, such
+        as Chrome notifications.</p>
+
+        <h3>Procedure</h3>
+        <p>You will be required to install a Chrome browser extension (small
+        piece of software) in the Chrome browser on your computer. The browser
+        extension will detect when you've experienced an infrequent event, like
+        seeing a Chrome notification, while browsing so that we can ask you to
+        answer a simple survey about your response to the event. We may also
+        collect diagnostic, system, and contextual information such as browser
+        version, OS, and the URL of the page you were on when the survey
+        appeared. We would like to run the study over a period of four months.
+        During this time, we do not expect you to change your normal web
+        browsing behavior. The number of surveys that you are shown will depend
+        on how often you encounter such events during your normal browsing.
+        Google may update the extension from time to time to change the
+        available survey questions. We expect that each survey will take 2-3
+        minutes to complete. Upon conclusion of the study, we will remove the
+        extension from your computer.</p>
+
+        <h3>Potential Risks</h3>
+        <p>Each browser extension will contain a randomly generated ID number
+        to enable us to group survey responses from a single participant. You
+        can reset this ID number by uninstalling and reinstalling the
+        extension. If you provide identifying information in response to any of
+        the survey questions, then Google may know personal information about
+        you and will be able to associate it with your other responses in the
+        study. You should only provide information that you are comfortable
+        sharing with Google. Otherwise, there are no special risks associated
+        with the study beyond the risks posed by normal internet usage.</p>
+
+        <h3>Privacy and Confidentiality</h3>
+        <p>All logged data will be stored on a secure Google server accessible
+        only to the researchers involved in this study. Any information that is
+        obtained in connection with this study and could identify you will
+        remain confidential within Google. Google may, however, publish the
+        results of this study along with data collected from the study in an
+        aggregated form, and may publish quotes from your survey responses as
+        long as they don't contain personally identifiable information.</p>
+
+        <h3>Data Use</h3>
+        <p>The survey responses that you provide to Google will be used to
+        improve Google's products and services.</p>
+
+        <h3>Participation and Withdrawal</h3>
+        <p>Your participation in this research study is voluntary and you may
+        withdraw at any time. You may remove the study extension at any time by
+        following <a target="_blank"
+        href="https://support.google.com/chrome/answer/113907?hl=en">these
+        instructions</a>. Any survey responses that you have already submitted
+        will continue to be part of the study data.</p>
+
+        <h3>Identification of Investigators</h3>
+        <p>If you have any questions or concerns about the research, please
+        feel free to contact:
+        <br>Rob Reeder, chrome-experience-sampling@google.com</p>
+      </div>
     </div>
 
-    <div class="centered inner-centering alert-gentle hidden" id="top-blurb">
-      <b>Thank you for your participation in our research study.</b>
-      <br>
-      It is being conducted by members of the Chrome team at Google Inc
-      ("Google").
+    <div class="scroll-constant">
+      <div id="consent-form-holder"
+          class="hidden centered inner-centering bottom-text">
+        <a href="surveys/setup.html" id="give-consent" class="consent-link">I
+            acknowledge that I have read this informed consent and agree to the
+            terms</a>
+        <br>
+        <a href="#" id="no-consent" class="consent-link">No thanks,
+            I prefer not to participate</a>
+      </div>
+      <div id="retract-consent"
+          class="hidden alert centered inner-centering bottom-text">
+        <p>You previously signed this consent form.<br>If you no longer want to
+        participate, you should <a target="_blank"
+        href="https://support.google.com/chrome/answer/113907?hl=en"
+        id="uninstall">uninstall</a> this extension.</p>
+      </div>
     </div>
 
-    <div id="study-information" class="hidden centered">
-      <h3>Purpose of the study</h3>
-      <p>We are looking to better understand how people interpret and
-      interact with Chrome and the Web during certain infrequent
-      events, such as Chrome notifications.</p>
-
-      <h3>Procedure</h3>
-      <p>You will be required to install a Chrome browser extension
-      (small piece of software) in the Chrome browser on your
-      computer.  The browser extension will detect when you’ve
-      experienced an infrequent event, like seeing a Chrome
-      notification, while browsing so that we can ask you to answer
-      a simple survey about your response to the event.  We may
-      also collect diagnostic, system, and contextual information such
-      as browser version, OS, and the URL of the page you were on when
-      the survey appeared. We would like to run the study over a
-      period of four months.   During this time, we do not expect you
-      to change your normal web browsing behavior.  The number of
-      surveys that you are shown will depend on how often you
-      encounter such events during your normal browsing. Google may
-      update the extension from time to time to change the available
-      survey questions.  We expect that each survey will take 2-3
-      minutes to complete.  Upon conclusion of the study, we will
-      remove the extension from your computer.</p>
-
-      <h3>Potential Risks</h3>
-      <p>Each browser extension will contain a randomly generated ID
-      number to enable us to group survey responses from a single
-      participant.  You can reset this ID number by uninstalling and
-      reinstalling the extension. If you provide identifying
-      information in response to any of the survey questions, then
-      Google may know personal information about you and will be able
-      to associate it with your other responses in the study.  You
-      should only provide information that you are comfortable sharing
-      with Google.  Otherwise, there are no special risks associated
-      with the study beyond the risks posed by normal internet usage.</p>
-
-      <h3>Privacy and Confidentiality</h3>
-      <p>All logged data will be stored on a secure Google server
-      accessible only to the researchers involved in this study. Any
-      information that is obtained in connection with this study and
-      could identify you will remain confidential within Google.
-      Google may, however, publish the results of this study along
-      with data collected from the study in an aggregated form, and
-      may publish quotes from your survey responses as long
-      as they don’t contain personally identifiable information.</p>
-
-      <h3>Data Use</h3>
-      <p>The survey responses that you provide to Google will be used to
-      improve Google's products and services.</p>
-
-      <h3>Participation and Withdrawal</h3>
-      <p>Your participation in this research study is voluntary and you may
-      withdraw at any time. You may remove the study extension at any time by
-      following <a href="https://support.google.com/chrome/answer/113907?hl=en">these
-      instructions</a>. Any survey responses that you have already
-      submitted will continue to be part of the study data.</p>
-
-      <h3>Identification of Investigators</h3>
-      <p>If you have any questions or concerns about the research, please feel
-      free to contact: Rob Reeder, chrome-experience-sampling@google.com</p>
-    </div>
-  </div>
-
-  <div id="consent-form-holder" class="hidden centered inner-centering">
-    <a href="surveys/setup.html" id="give-consent" class="consent-link">I
-        acknowledge that I have read this informed consent and agree to the
-        terms</a>
-    <br>
-    <a href="#" id="no-consent" class="consent-link">No thanks, I prefer not to
-        participate</a>
-  </div>
-
-  <div id="retract-consent" class="hidden alert centered inner-centering">
-    <p>You previously signed this consent form. If you no longer want to
-    participate, you should <a
-    href="https://support.google.com/chrome/answer/113907?hl=en"
-    id="uninstall">uninstall</a> this extension.</p>
   </div>
 
 </body>


### PR DESCRIPTION
This keeps the consent options always visible on the consent doc. Hopefully this will make it more apparent to users that they need to do something.

Issue #50

![screen shot 2014-11-21 at 5 21 05 pm](https://cloud.githubusercontent.com/assets/4962198/5152268/b79450d6-71a3-11e4-9273-e50f75b2b032.png)

![screen shot 2014-11-21 at 5 21 08 pm](https://cloud.githubusercontent.com/assets/4962198/5152269/bbe8f952-71a3-11e4-8cb2-e6f412f4cc9d.png)
![screen shot 2014-11-21 at 5 24 57 pm](https://cloud.githubusercontent.com/assets/4962198/5152270/beef286a-71a3-11e4-9e29-d58ae1852804.png)
