### PR TITLE
Send setup survey responses to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Backend: Setup and deployment
 
 - Install the
   [App Engine GCS Client Libary](https://developers.google.com/appengine/docs/python/googlecloudstorageclient/download)
-  into the backend (*this may not work on old versions of pip*):
-
+  into the backend
+  
+  If you use pip:
   `pip install -t backend/lib GoogleAppEngineCloudStorageClient`
+
+  You should end up with a folder named "cloudstorage" under backend/.
 
 - To run the development server:
 

--- a/backend/messages.py
+++ b/backend/messages.py
@@ -16,7 +16,7 @@ class ResponseMessage(messages.Message):
 
 class SurveyMessage(messages.Message):
   survey_type = messages.StringField(1, required=True)
-  participant_id = messages.IntegerField(2, required=True)
+  participant_id = messages.StringField(2, required=True)
   date_taken = message_types.DateTimeField(3, required=True)
   responses = messages.MessageField(ResponseMessage, 4, repeated=True)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -22,7 +22,7 @@ class SurveyModel(ndb.Model):
   survey_type = ndb.StringProperty(indexed=True, required=True)
   participant_id = ndb.StringProperty(indexed=True, required=True)
   date_taken = ndb.DateTimeProperty(required=True)
-  date_received = ndb.DateTimeProperty(auto_now_add=True, required=True)
+  date_received = ndb.DateTimeProperty(auto_now_add=True)
   responses = ndb.StructuredProperty(ResponseModel, repeated=True)
 
   @staticmethod

--- a/backend/models.py
+++ b/backend/models.py
@@ -20,7 +20,7 @@ class ResponseModel(ndb.Model):
 
 class SurveyModel(ndb.Model):
   survey_type = ndb.StringProperty(indexed=True)
-  participant_id = ndb.IntegerProperty(indexed=True)
+  participant_id = ndb.StringProperty(indexed=True)
   date_taken = ndb.DateTimeProperty()
   date_received = ndb.DateTimeProperty(auto_now_add=True)
   responses = ndb.StructuredProperty(ResponseModel, repeated=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -19,10 +19,10 @@ class ResponseModel(ndb.Model):
 
 
 class SurveyModel(ndb.Model):
-  survey_type = ndb.StringProperty(indexed=True)
-  participant_id = ndb.StringProperty(indexed=True)
-  date_taken = ndb.DateTimeProperty()
-  date_received = ndb.DateTimeProperty(auto_now_add=True)
+  survey_type = ndb.StringProperty(indexed=True, required=True)
+  participant_id = ndb.StringProperty(indexed=True, required=True)
+  date_taken = ndb.DateTimeProperty(required=True)
+  date_received = ndb.DateTimeProperty(auto_now_add=True, required=True)
   responses = ndb.StructuredProperty(ResponseModel, repeated=True)
 
   @staticmethod

--- a/extension/background.js
+++ b/extension/background.js
@@ -15,7 +15,7 @@
 var cesp = cesp || {};
 
 cesp.operatingSystem = '';
-cesp.participantId = '';
+cesp.participantId = null;
 cesp.openTabId = -1;
 
 // Settings.
@@ -60,13 +60,13 @@ function setSurveysShownStorageValue(newCount) {
  */
 function setNewParticipantId() {
   // If the participant ID already has a value, this is redundant.
-  if (cesp.participantId !== '') return;
+  if (cesp.participantId) return;
 
   var charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";
   var participantId = '';
   for (var i = 0; i < 100; i++) {
     var rand = Math.floor(Math.random() * charset.length);
-    participantId += charset.substring(rand, rand + 1);
+    participantId += charset.charAt(rand);
   }
 
   cesp.participantId = participantId;
@@ -80,10 +80,10 @@ function setNewParticipantId() {
  */
 function getParticipantIdFromStorage() {
   // If the participant ID already has a value, this is redundant.
-  if (cesp.participantId !== '') return;
+  if (cesp.participantId) return;
 
   chrome.storage.local.get(cesp.PARTICIPANT_ID_LOOKUP, function(lookup) {
-    if (!lookup || lookup[cesp.PARTICIPANT_ID_LOOKUP] == null) {
+    if (!lookup || !lookup[cesp.PARTICIPANT_ID_LOOKUP) {
       setNewParticipantId();
     } else {
       cesp.participantId = lookup[cesp.PARTICIPANT_ID_LOOKUP];

--- a/extension/background.js
+++ b/extension/background.js
@@ -15,6 +15,7 @@
 var cesp = cesp || {};
 
 cesp.operatingSystem = '';
+cesp.participantId = '';
 cesp.openTabId = -1;
 
 // Settings.
@@ -30,6 +31,7 @@ cesp.SURVEY_COUNT_RESET_ALARM_NAME = 'surveyCountReset';
 cesp.NOTIFICATION_ALARM_NAME = 'notificationTimeout';
 cesp.UNINSTALL_ALARM_NAME = 'uninstallAlarm';
 cesp.READY_FOR_SURVEYS = 'readyForSurveys';
+cesp.PARTICIPANT_ID_LOOKUP = 'participantId';
 
 // SETUP
 
@@ -54,6 +56,42 @@ function setSurveysShownStorageValue(newCount) {
 }
 
 /**
+ * A helper method for generating and setting a new participant ID.
+ */
+function setNewParticipantId() {
+  // If the participant ID already has a value, this is redundant.
+  if (cesp.participantId !== '') return;
+
+  var charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";
+  var participantId = '';
+  for (var i = 0; i < 100; i++) {
+    var rand = Math.floor(Math.random() * charset.length);
+    participantId += charset.substring(rand, rand + 1);
+  }
+
+  cesp.participantId = participantId;
+  var items = {};
+  items[cesp.PARTICIPANT_ID_LOOKUP] = participantId;
+  chrome.storage.local.set(items);
+}
+
+/**
+ * A helper method for ensuring the participant ID is always set.
+ */
+function getParticipantIdFromStorage() {
+  // If the participant ID already has a value, this is redundant.
+  if (cesp.participantId !== '') return;
+
+  chrome.storage.local.get(cesp.PARTICIPANT_ID_LOOKUP, function(lookup) {
+    if (!lookup || lookup[cesp.PARTICIPANT_ID_LOOKUP] == null) {
+      setNewParticipantId();
+    } else {
+      cesp.participantId = lookup[cesp.PARTICIPANT_ID_LOOKUP];
+    }
+  });
+}
+
+/**
  * Sets up basic state for the extension. Called when extension is installed.
  * @param {object} details The details of the chrome.runtime.onInstalled event.
  */
@@ -62,6 +100,7 @@ function setupState(details) {
   // reasons (extension or browser update).
   if (details.reason !== 'install') return;
 
+  setNewParticipantId();
   setReadyForSurveysStorageValue(false);
   chrome.runtime.getPlatformInfo(function(platformInfo) {
     cesp.operatingSystem = platformInfo.os;
@@ -159,6 +198,7 @@ function storageUpdated(changes, areaName) {
 chrome.runtime.onInstalled.addListener(getConsentStatus);
 chrome.runtime.onStartup.addListener(getConsentStatus);
 chrome.runtime.onInstalled.addListener(setupState);
+chrome.runtime.onStartup.addListener(getParticipantIdFromStorage);
 
 // SURVEY HANDLING
 
@@ -333,3 +373,22 @@ function loadSurvey(element, decision, timePromptShown, timePromptClicked) {
 // Trigger the new survey prompt when the participant makes a decision about an
 // experience sampling element.
 chrome.experienceSamplingPrivate.onDecision.addListener(showSurveyNotification);
+
+/**
+ * Handle the submission of a completed survey.
+ */
+function handleCompletedSurvey(message) {
+  var record = new SurveySubmission.SurveyRecord(
+      message['survey_type'],
+      cesp.participantId,
+      (new Date),
+      message['responses']);
+  var successCallback = function() {
+    console.log('Survey submitted successfully');
+  };
+  var errorCallback = function(responseCode) {
+    console.log('Survey submission error: ' + responseCode);
+  };
+  SurveySubmission.sendSurveyRecord(record, successCallback, errorCallback);
+}
+chrome.runtime.onMessage.addListener(handleCompletedSurvey);

--- a/extension/background.js
+++ b/extension/background.js
@@ -83,7 +83,7 @@ function getParticipantIdFromStorage() {
   if (cesp.participantId) return;
 
   chrome.storage.local.get(cesp.PARTICIPANT_ID_LOOKUP, function(lookup) {
-    if (!lookup || !lookup[cesp.PARTICIPANT_ID_LOOKUP) {
+    if (!lookup || !lookup[cesp.PARTICIPANT_ID_LOOKUP]) {
       setNewParticipantId();
     } else {
       cesp.participantId = lookup[cesp.PARTICIPANT_ID_LOOKUP];
@@ -387,6 +387,7 @@ function handleCompletedSurvey(message) {
     console.log('Survey submitted successfully');
   };
   var errorCallback = function(responseCode) {
+    console.log(responseCode);
     console.log('Survey submission error: ' + responseCode);
   };
   SurveySubmission.sendSurveyRecord(record, successCallback, errorCallback);

--- a/extension/constants.js
+++ b/extension/constants.js
@@ -73,6 +73,7 @@ constants.EventType = {
 
 // The JavaScript files that load each survey.
 constants.SurveyLocation = {
+  SETUP: 'setup.js',
   SSL_OVERRIDABLE_PROCEED: 'ssl-overridable-proceed.js',
   SSL_OVERRIDABLE_NOPROCEED: 'ssl-overridable-noproceed.js',
   SSL_NONOVERRIDABLE: 'ssl-nonoverridable.js',

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -4,6 +4,7 @@
 
 var setupSurvey = {};  // Namespace variable
 setupSurvey.status = constants.SETUP_PENDING;
+setupSurvey.questions = [];
 
 /**
  * A helper method for updating the value in local storage.
@@ -13,6 +14,14 @@ function setSetupStorageValue(newState) {
   var items = {};
   items[constants.SETUP_KEY] = newState;
   chrome.storage.local.set(items);
+}
+
+/**
+ * 
+ */
+function addQuestion(parentNode, question) {
+  setupSurvey.questions.push(question);
+  parentNode.appendChild(question.makeDOMTree());
 }
 
 /**
@@ -34,7 +43,7 @@ function addQuestions(parentNode) {
         '65 or older'
       ],
       constants.Randomize.NONE);
-  parentNode.appendChild(age.makeDOMTree());
+  addQuestion(parentNode, age);
 
   var gender = new FixedQuestion(
       constants.QuestionType.CHECKBOX,
@@ -47,7 +56,7 @@ function addQuestions(parentNode) {
         'I prefer not to answer'
       ],
       constants.Randomize.NONE);
-  parentNode.appendChild(gender.makeDOMTree());
+  addQuestion(parentNode, gender);
 
   var education = new FixedQuestion(
       constants.QuestionType.RADIO,
@@ -64,13 +73,13 @@ function addQuestions(parentNode) {
         constants.OTHER
       ],
       constants.Randomize.NONE);
-  parentNode.appendChild(education.makeDOMTree());
+  addQuestion(parentNode, education);
 
   var occupation = new EssayQuestion(
       constants.QuestionType.SHORT_STRING,
       'What is your occupation?',
       true);
-  parentNode.appendChild(occupation.makeDOMTree());
+  addQuestion(parentNode, occupation);
 
   var country = new FixedQuestion(
       constants.QuestionType.DROPDOWN,
@@ -382,7 +391,7 @@ function addQuestions(parentNode) {
       ],
       constants.Randomize.NONE);
   country.addDependentQuestion(state, 'United States of America');
-  parentNode.appendChild(country.makeDOMTree());
+  addQuestion(parentNode, country);
 
   var source = new FixedQuestion(
       constants.QuestionType.RADIO,
@@ -396,7 +405,7 @@ function addQuestions(parentNode) {
         constants.OTHER
       ],
       constants.Randomize.ANCHOR_LAST);
-  parentNode.appendChild(source.makeDOMTree());
+  addQuestion(parentNode, source);
 
   var computer = new FixedQuestion(
       constants.QuestionType.RADIO,
@@ -411,7 +420,7 @@ function addQuestions(parentNode) {
         constants.OTHER
       ],
       constants.Randomize.NONE);
-  parentNode.appendChild(computer.makeDOMTree());
+  addQuestion(parentNode, computer);
 
   var computerOwner = new FixedQuestion(
       constants.QuestionType.RADIO,
@@ -425,7 +434,7 @@ function addQuestions(parentNode) {
         constants.OTHER
       ],
       constants.Randomize.NONE);
-  parentNode.appendChild(computerOwner.makeDOMTree());
+  addQuestion(parentNode, computerOwner);
 
   var antivirus = new FixedQuestion(
       constants.QuestionType.RADIO,
@@ -437,7 +446,7 @@ function addQuestions(parentNode) {
         'I don\'t know'
       ],
       constants.Randomize.NONE);
-  parentNode.appendChild(antivirus.makeDOMTree());
+  addQuestion(parentNode, antivirus);
 }
 
 /**
@@ -485,6 +494,13 @@ function setupFormSubmitted(event) {
     chrome.management.uninstallSelf();
     return;
   }
+
+  chrome.runtime.sendMessage(
+    {
+      'survey_type': constants.SurveyLocation.SETUP,
+      'responses': getFormValues(document['survey-form'])
+    }
+  );
 
   setSetupStorageValue(constants.SETUP_COMPLETED);
   $('explanation').classList.add('hidden');

--- a/extension/survey-submission.js
+++ b/extension/survey-submission.js
@@ -235,6 +235,7 @@ SurveySubmission.sendSurveyRecord = function(surveyRecord, successCallback,
   for (var i = 0; i < surveyRecord.responses.length; i++) {
     data.responses.push(surveyRecord.responses[i]);
   }
+  console.log(JSON.stringify(data));
   var xhr = new XMLHttpRequest();
   function onLoadHandler(event) {
     if (xhr.readyState === 4) {

--- a/extension/survey-submission.js
+++ b/extension/survey-submission.js
@@ -235,7 +235,6 @@ SurveySubmission.sendSurveyRecord = function(surveyRecord, successCallback,
   for (var i = 0; i < surveyRecord.responses.length; i++) {
     data.responses.push(surveyRecord.responses[i]);
   }
-  console.log(JSON.stringify(data));
   var xhr = new XMLHttpRequest();
   function onLoadHandler(event) {
     if (xhr.readyState === 4) {

--- a/extension/surveys/setup.html
+++ b/extension/surveys/setup.html
@@ -6,6 +6,7 @@
 <script src="../constants.js"></script>
 <script src="survey-generator.js"></script>
 <script src="common-questions.js"></script>
+<script src="../survey-submission.js"></script>
 <script src="../setup.js"></script>
 </head>
 

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -150,6 +150,7 @@ FixedQuestion.prototype.makeDOMTree = function() {
       break;
     case constants.QuestionType.DROPDOWN:
       var select = document.createElement('select');
+      select.setAttribute('name', shrunkenQuestion);
       var depAnswer;
       var answerChoices = [];
       for (var i = 0; i < this.answers.length; i++) {
@@ -473,4 +474,33 @@ function makeSubmitButtonDOM() {
   fieldset.classList.add('submit');
   fieldset.appendChild(button);
   return fieldset;
+}
+
+/**
+ * Extracts the question and answer values from a completed survey form.
+ * @param {Object} form The containing <form> DOM node.
+ * @returns {SurveySubmission.Response} The question and associated answer.
+ */
+function getFormValues(form) {
+  var responses = [];
+  for (var i = 0; i < setupSurvey.questions.length; i++) {
+    var question = setupSurvey.questions[i];  // The Question object
+    var questionStr = setupSurvey.questions[i].question;  // The question text
+    var questionLookup = getDomNameFromValue(questionStr);  // The DOM ID
+    if (question.questionType === constants.QuestionType.CHECKBOX) {
+      // Checkboxes may have multiple answers.
+      var answerList = document.querySelectorAll(
+          'input[name="' + questionLookup + '"]:checked');
+      for (var j = 0; j < answerList.length; j++) {
+        var response = new SurveySubmission.Response(
+            questionStr, answerList[j].value);
+        responses.push(response);
+      }
+    } else {
+      var answer = form[questionLookup].value || 'NOANSWER';
+      var response = new SurveySubmission.Response(questionStr, answer);
+      responses.push(response);
+    }
+  }
+  return responses;
 }


### PR DESCRIPTION
The setup survey presentation & submission logic had gotten disconnected. This hooks them up again so that setup survey responses are actually sent to the server.

Incidentally, as part of that:
- Now setting participant IDs
- Discovered that CHECKBOX questions were missing a name value; added that.
