### PR TITLE
Simplify startup callbacks

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -33,8 +33,6 @@ cesp.UNINSTALL_ALARM_NAME = 'uninstallAlarm';
 cesp.READY_FOR_SURVEYS = 'readyForSurveys';
 cesp.PARTICIPANT_ID_LOOKUP = 'participantId';
 
-function err(err) { console.error(err); }
-
 // SETUP
 
 /**

--- a/extension/background.js
+++ b/extension/background.js
@@ -145,16 +145,16 @@ chrome.alarms.onAlarm.addListener(resetSurveyCount);
  */
 function maybeShowConsentOrSetupSurvey() {
   var setupCallback = function(lookup) {
-    if (!setupLookup || setupLookup[constants.SETUP_KEY] == null ||
-        setupLookup[constants.SETUP_KEY] == constants.SETUP_PENDING) {
+    if (!lookup || !lookup[constants.SETUP_KEY] ||
+        lookup[constants.SETUP_KEY] === constants.SETUP_PENDING) {
       chrome.tabs.create(
           {'url': chrome.extension.getURL('surveys/setup.html')});
-    } else if (setupLookup[constants.SETUP_KEY] == constants.SETUP_COMPLETED) {
+    } else if (lookup[constants.SETUP_KEY] === constants.SETUP_COMPLETED) {
       setReadyForSurveysStorageValue(true);
     }
   };
   var consentCallback = function(lookup) {
-    if (!lookup || lookup[constants.CONSENT_KEY] == null ||
+    if (!lookup || !lookup[constants.CONSENT_KEY] ||
         lookup[constants.CONSENT_KEY] === constants.CONSENT_PENDING) {
       chrome.storage.onChanged.addListener(storageUpdated);
       chrome.tabs.create({'url': chrome.extension.getURL('consent.html')});

--- a/extension/background.js
+++ b/extension/background.js
@@ -33,6 +33,8 @@ cesp.UNINSTALL_ALARM_NAME = 'uninstallAlarm';
 cesp.READY_FOR_SURVEYS = 'readyForSurveys';
 cesp.PARTICIPANT_ID_LOOKUP = 'participantId';
 
+function err(err) { console.error(err); }
+
 // SETUP
 
 /**
@@ -140,45 +142,33 @@ function resetSurveyCount(alarm) {
 chrome.alarms.onAlarm.addListener(resetSurveyCount);
 
 /**
- * Retrieves the registration status from Local Storage.
+ * Checks whether participant has granted consent and/or completed the
+ * demographic survey. If not, get the participant started.
  */
-function getConsentStatus() {
-  chrome.storage.local.get(constants.CONSENT_KEY, maybeShowConsentForm);
-}
-
-/**
- * Checks whether consent has been granted yet; if not, opens the consent form.
- * @param {object} consentLookup Object containing consent status (or empty).
- */
-function maybeShowConsentForm(consentLookup) {
-  if (!consentLookup || consentLookup[constants.CONSENT_KEY] == null ||
-      consentLookup[constants.CONSENT_KEY] == constants.CONSENT_PENDING) {
-    chrome.storage.onChanged.addListener(storageUpdated);
-    chrome.tabs.create({'url': chrome.extension.getURL('consent.html')});
-  } else if (consentLookup[constants.CONSENT_KEY] ==
-             constants.CONSENT_REJECTED) {
-    chrome.management.uninstallSelf();
-  } else if (consentLookup[constants.CONSENT_KEY] ==
-             constants.CONSENT_GRANTED) {
-    // Someone might have filled out the consent form previously but not
-    // filled out the setup survey. Check to see if that's the case.
-    chrome.storage.local.get(constants.SETUP_KEY, maybeShowSetupSurvey);
-  }
-}
-
-/**
- * Checks whether the setup survey has been completed yet. If it has been, we
- * are now ready to start showing surveys. If not, we need to listen for
- * when it's completed.
- * @param {object} setupLookup Object containing setup survey status (or empty).
- */
-function maybeShowSetupSurvey(setupLookup) {
-  if (!setupLookup || setupLookup[constants.SETUP_KEY] == null ||
-      setupLookup[constants.SETUP_KEY] == constants.SETUP_PENDING) {
-    chrome.tabs.create({'url': chrome.extension.getURL('surveys/setup.html')});
-  } else if (setupLookup[constants.SETUP_KEY] == constants.SETUP_COMPLETED) {
-    setReadyForSurveysStorageValue(true);
-  }
+function maybeShowConsentOrSetupSurvey() {
+  var setupCallback = function(lookup) {
+    if (!setupLookup || setupLookup[constants.SETUP_KEY] == null ||
+        setupLookup[constants.SETUP_KEY] == constants.SETUP_PENDING) {
+      chrome.tabs.create(
+          {'url': chrome.extension.getURL('surveys/setup.html')});
+    } else if (setupLookup[constants.SETUP_KEY] == constants.SETUP_COMPLETED) {
+      setReadyForSurveysStorageValue(true);
+    }
+  };
+  var consentCallback = function(lookup) {
+    if (!lookup || lookup[constants.CONSENT_KEY] == null ||
+        lookup[constants.CONSENT_KEY] === constants.CONSENT_PENDING) {
+      chrome.storage.onChanged.addListener(storageUpdated);
+      chrome.tabs.create({'url': chrome.extension.getURL('consent.html')});
+    } else if (lookup[constants.CONSENT_KEY] === constants.CONSENT_REJECTED) {
+      chrome.management.uninstallSelf();
+    } else if (lookup[constants.CONSENT_KEY] === constants.CONSENT_GRANTED) {
+      // Someone might have filled out the consent form previously but not
+      // filled out the setup survey. Check to see if that's the case.
+      chrome.storage.local.get(constants.SETUP_KEY, setupCallback);
+    }
+  };
+  chrome.storage.local.get(constants.CONSENT_KEY, consentCallback);
 }
 
 /**
@@ -195,8 +185,8 @@ function storageUpdated(changes, areaName) {
 }
 
 // Performs consent and registration checks on startup and install.
-chrome.runtime.onInstalled.addListener(getConsentStatus);
-chrome.runtime.onStartup.addListener(getConsentStatus);
+chrome.runtime.onInstalled.addListener(maybeShowConsentOrSetupSurvey);
+chrome.runtime.onStartup.addListener(maybeShowConsentOrSetupSurvey);
 chrome.runtime.onInstalled.addListener(setupState);
 chrome.runtime.onStartup.addListener(getParticipantIdFromStorage);
 


### PR DESCRIPTION
Previous, on startup:
getConsentStatus() --> maybeShowConsentForm() --> maybeShowSetupSurvey().
with no other callers.

This simplifies the three into a single method, maybeShowConsentOrSetupSurvey.
