### PR TITLE
Send results of dependent questions

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -365,7 +365,6 @@ chrome.experienceSamplingPrivate.onDecision.addListener(showSurveyNotification);
  * Handle the submission of a completed survey.
  */
 function handleCompletedSurvey(message) {
-  console.log(JSON.stringify(message['responses']));
   getParticipantId().then(function(participantId) {
     var record = new SurveySubmission.SurveyRecord(
         message['survey_type'],

--- a/extension/background.js
+++ b/extension/background.js
@@ -365,6 +365,7 @@ chrome.experienceSamplingPrivate.onDecision.addListener(showSurveyNotification);
  * Handle the submission of a completed survey.
  */
 function handleCompletedSurvey(message) {
+  console.log(JSON.stringify(message['responses']));
   getParticipantId().then(function(participantId) {
     var record = new SurveySubmission.SurveyRecord(
         message['survey_type'],

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -484,9 +484,8 @@ function makeSubmitButtonDOM() {
  */
 function getFormValues(questionArr, form) {
   var responses = [];
-  for (var i = 0; i < questionArr.length; i++) {
-    var question = questionArr[i];  // The Question object
-    var questionStr = questionArr[i].question;  // The question text
+  function grabQuestion(question) {
+    var questionStr = question.question;  // The question text
     var questionLookup = getDomNameFromValue(questionStr);  // The DOM ID
     if (question.questionType === constants.QuestionType.CHECKBOX) {
       // Checkboxes may have multiple answers.
@@ -513,6 +512,11 @@ function getFormValues(questionArr, form) {
       var response = new SurveySubmission.Response(questionStr, answer);
       responses.push(response);
     }
+    if (question.depChild)
+      grabQuestion(question.depChild);
+  }
+  for (var i = 0; i < questionArr.length; i++) {
+    grabQuestion(questionArr[i]);
   }
   return responses;
 }


### PR DESCRIPTION
We need to send the results of dependent questions too. Previously they were being omitted due to the way the set of questions was traversed for upload.
