### PR TITLE
Send OS automagically

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -105,8 +105,10 @@ function maybeShowConsentOrSetupSurvey() {
   var setupCallback = function(lookup) {
     if (!lookup || !lookup[constants.SETUP_KEY] ||
         lookup[constants.SETUP_KEY] === constants.SETUP_PENDING) {
-      chrome.tabs.create(
-          {'url': chrome.extension.getURL('surveys/setup.html')});
+      getOperatingSystem().then(function(os) {
+        chrome.tabs.create(
+            {'url': chrome.extension.getURL('surveys/setup.html?os=' + os)});
+      });
     } else if (lookup[constants.SETUP_KEY] === constants.SETUP_COMPLETED) {
       setReadyForSurveysStorageValue(true);
     }
@@ -115,7 +117,10 @@ function maybeShowConsentOrSetupSurvey() {
     if (!lookup || !lookup[constants.CONSENT_KEY] ||
         lookup[constants.CONSENT_KEY] === constants.CONSENT_PENDING) {
       chrome.storage.onChanged.addListener(storageUpdated);
-      chrome.tabs.create({'url': chrome.extension.getURL('consent.html')});
+      getOperatingSystem().then(function(os) {
+        chrome.tabs.create(
+            {'url': chrome.extension.getURL('consent.html?os=' + os)});
+      });
     } else if (lookup[constants.CONSENT_KEY] === constants.CONSENT_REJECTED) {
       chrome.management.uninstallSelf();
     } else if (lookup[constants.CONSENT_KEY] === constants.CONSENT_GRANTED) {
@@ -176,7 +181,7 @@ function getParticipantId() {
  * A helper method for getting the operating system.
  * @returns {Promise} A promise that resolves with the operating system.
  */
-function getOperatingSytem() {
+function getOperatingSystem() {
   return new Promise(function(resolve, reject) {
     chrome.runtime.getPlatformInfo(function(platformInfo) {
       resolve(platformInfo.os);
@@ -341,7 +346,7 @@ function loadSurvey(element, decision, timePromptShown, timePromptClicked) {
         !surveyUrl) {
       return;
     }
-    getOperatingSytem().then(function(os) {
+    getOperatingSystem().then(function(os) {
       visitUrl = encodeURIComponent(visitUrl);
       var openUrl = 'surveys/survey.html?js=' + surveyUrl + '&url=' + visitUrl
           + '&os=' + os;

--- a/extension/consent.js
+++ b/extension/consent.js
@@ -35,6 +35,8 @@ function setupConsentForm(savedState) {
     $('top-blurb').classList.remove('hidden');
     $('consent-form-holder').classList.remove('hidden');
     $('give-consent').addEventListener('click', userGrantConsent);
+    $('give-consent').href = 'surveys/setup.html?' +
+        window.location.search.substring(1);
     $('no-consent').addEventListener('click', userRejectConsent)
   } else if (consentForm.status == constants.CONSENT_GRANTED) {
     // Show the consent form and the user's decision.

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -497,10 +497,14 @@ function setupFormSubmitted(event) {
     return;
   }
 
+  var responses = getFormValues(setupSurvey.questions, document['survey-form']);
+  var query = window.location.search.substring(1);
+  var os = new SurveySubmission.Response('OS', query.split('=')[1]);
+  responses.push(os);
   chrome.runtime.sendMessage(
     {
       'survey_type': constants.SurveyLocation.SETUP,
-      'responses': getFormValues(setupSurvey.questions, document['survey-form'])
+      'responses': responses
     }
   );
 

--- a/extension/surveys/driver.js
+++ b/extension/surveys/driver.js
@@ -36,7 +36,7 @@ function loadSurveyScript() {
   var query = window.location.search.substring(1);
   if (!query) handleError();
   var splitIntoPairs = query.split('&');
-  if (!splitIntoPairs || splitIntoPairs.length < 2) handleError();
+  if (!splitIntoPairs || splitIntoPairs.length < 3) handleError();
 
   // Determine the type of survey to show.
   var jsUrl = parseKeyValuePair('js', splitIntoPairs[0]);

--- a/extension/surveys/setup.html
+++ b/extension/surveys/setup.html
@@ -12,7 +12,7 @@
 
 <body>
   <div class="centered inner-centering">
-    <h1>Chrome Survey Setup</h1>
+    <h1>Chrome User Experience Surveys: Setup</h1>
   </div>
 
   <div class="centered inner-centering alert hidden" id="explanation">


### PR DESCRIPTION
Instead of asking the user for the OS, report it automatically as part of the demographic survey setup when it's submitted.

For issue #32.
