### PR TITLE
Fix for inline install bug

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -235,10 +235,12 @@ function showSurveyNotification(element, decision) {
   }
   chrome.storage.local.get(cesp.READY_FOR_SURVEYS, function(items) {
     if (!items[cesp.READY_FOR_SURVEYS]) return;
+
     chrome.storage.local.get(cesp.SURVEYS_SHOWN_TODAY, function(items) {
       if (items[cesp.SURVEYS_SHOWN_TODAY] >= cesp.MAX_SURVEYS_PER_DAY) {
         return;
       }
+
       clearNotifications();
 
       var timePromptShown = new Date();


### PR DESCRIPTION
An unnecessary if-statement was filtering out inline extension install events.
