### PR TITLE
Use sync, not local, storage for values

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -44,7 +44,7 @@ cesp.MINIMUM_SURVEY_DELAY = 300000;  // 5 minutes in ms.
 function setReadyForSurveysStorageValue(newState) {
   var items = {};
   items[cesp.READY_FOR_SURVEYS] = newState;
-  chrome.storage.local.set(items);
+  chrome.storage.sync.set(items);
 }
 
 /**
@@ -54,7 +54,7 @@ function setReadyForSurveysStorageValue(newState) {
 function setSurveysShownDaily(newCount) {
   var items = {};
   items[cesp.SURVEYS_SHOWN_TODAY] = newCount;
-  chrome.storage.local.set(items);
+  chrome.storage.sync.set(items);
 }
 
 /**
@@ -64,7 +64,7 @@ function setSurveysShownDaily(newCount) {
 function setSurveysShownWeekly(newCount) {
   var items = {};
   items[cesp.SURVEYS_SHOWN_THIS_WEEK] = newCount;
-  chrome.storage.local.set(items);
+  chrome.storage.sync.set(items);
 }
 
 /**
@@ -73,7 +73,7 @@ function setSurveysShownWeekly(newCount) {
 function resetLastNotificationTimeStorageValue() {
   var items = {};
   items[cesp.LAST_NOTIFICATION_TIME] = Date.now();
-  chrome.storage.local.set(items);
+  chrome.storage.sync.set(items);
 }
 
 /**
@@ -162,10 +162,10 @@ function maybeShowConsentOrSetupSurvey() {
     } else if (lookup[constants.CONSENT_KEY] === constants.CONSENT_GRANTED) {
       // Someone might have filled out the consent form previously but not
       // filled out the setup survey. Check to see if that's the case.
-      chrome.storage.local.get(constants.SETUP_KEY, setupCallback);
+      chrome.storage.sync.get(constants.SETUP_KEY, setupCallback);
     }
   };
-  chrome.storage.local.get(constants.CONSENT_KEY, consentCallback);
+  chrome.storage.sync.get(constants.CONSENT_KEY, consentCallback);
 }
 
 /**
@@ -194,7 +194,7 @@ chrome.runtime.onInstalled.addListener(setupState);
  */
 function getParticipantId() {
   return new Promise(function(resolve, reject) {
-    chrome.storage.local.get(cesp.PARTICIPANT_ID_LOOKUP, function(lookup) {
+    chrome.storage.sync.get(cesp.PARTICIPANT_ID_LOOKUP, function(lookup) {
       if (lookup && lookup[cesp.PARTICIPANT_ID_LOOKUP])
         resolve(lookup[cesp.PARTICIPANT_ID_LOOKUP]);
 
@@ -207,7 +207,7 @@ function getParticipantId() {
       }
       var items = {};
       items[cesp.PARTICIPANT_ID_LOOKUP] = participantId;
-      chrome.storage.local.set(items);
+      chrome.storage.sync.set(items);
       resolve(participantId);
     });
   });
@@ -269,7 +269,7 @@ function showSurveyNotification(element, decision) {
       // Unsupported events.
       return;
   }
-  chrome.storage.local.get([cesp.READY_FOR_SURVEYS,
+  chrome.storage.sync.get([cesp.READY_FOR_SURVEYS,
                             cesp.LAST_NOTIFICATION_TIME], function(items) {
     if (!items[cesp.READY_FOR_SURVEYS]) return;
 
@@ -278,10 +278,10 @@ function showSurveyNotification(element, decision) {
         Date.now() - items[cesp.LAST_NOTIFICATION_TIME] <
         cesp.MINIMUM_SURVEY_DELAY) return;
 
-    chrome.storage.local.get(cesp.SURVEYS_SHOWN_TODAY, function(today) {
+    chrome.storage.sync.get(cesp.SURVEYS_SHOWN_TODAY, function(today) {
       if (today[cesp.SURVEYS_SHOWN_TODAY] >= cesp.MAX_SURVEYS_PER_DAY)
         return;
-      chrome.storage.local.get(cesp.SURVEYS_SHOWN_THIS_WEEK, function(week) {
+      chrome.storage.sync.get(cesp.SURVEYS_SHOWN_THIS_WEEK, function(week) {
         if (week[cesp.SURVEYS_SHOWN_THIS_WEEK] >= cesp.MAX_SURVEYS_PER_WEEK)
           return;
 
@@ -337,7 +337,7 @@ function showSurveyNotification(element, decision) {
  *     clicked the survey prompt notification.
  */
 function loadSurvey(element, decision, timePromptShown, timePromptClicked) {
-  chrome.storage.local.get(cesp.READY_FOR_SURVEYS, function(items) {
+  chrome.storage.sync.get(cesp.READY_FOR_SURVEYS, function(items) {
     if (!items[cesp.READY_FOR_SURVEYS]) return;
     var userDecision = decision['name'];
     if (userDecision !== constants.DecisionType.PROCEED &&

--- a/extension/background.js
+++ b/extension/background.js
@@ -236,12 +236,12 @@ function storageUpdated(changes, areaName) {
     return;
   if (changes[constants.CONSENT_KEY] &&
       changes[constants.CONSENT_KEY].newValue === constants.CONSENT_GRANTED) {
-    chrome.runtime.sendMessage({ 'message_type': constants.MSG_CONSENT; });
+    chrome.runtime.sendMessage({ 'message_type': constants.MSG_CONSENT });
   }
   if (changes[constants.SETUP_KEY] &&
       changes[constants.SETUP_KEY].newValue === constants.SETUP_COMPLETED) {
     setReadyForSurveysStorageValue(true);
-    chrome.runtime.sendMessage({ 'message_type': constants.MSG_SETUP; });
+    chrome.runtime.sendMessage({ 'message_type': constants.MSG_SETUP });
   }
 }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -232,9 +232,16 @@ function maybeShowConsentOrSetupSurvey() {
  * @param {string} areaName The name of the storage area.
  */
 function storageUpdated(changes, areaName) {
-  if (changes && changes[constants.SETUP_KEY] &&
-      changes[constants.SETUP_KEY].newValue == constants.SETUP_COMPLETED) {
+  if (!changes)
+    return;
+  if (changes[constants.CONSENT_KEY] &&
+      changes[constants.CONSENT_KEY].newValue === constants.CONSENT_GRANTED) {
+    chrome.runtime.sendMessage({ 'message_type': constants.MSG_CONSENT; });
+  }
+  if (changes[constants.SETUP_KEY] &&
+      changes[constants.SETUP_KEY].newValue === constants.SETUP_COMPLETED) {
     setReadyForSurveysStorageValue(true);
+    chrome.runtime.sendMessage({ 'message_type': constants.MSG_SETUP; });
   }
 }
 
@@ -470,6 +477,8 @@ chrome.experienceSamplingPrivate.onDecision.addListener(showSurveyNotification);
  * Handle the submission of a completed survey.
  */
 function handleCompletedSurvey(message) {
+  if (message[constants.MSG_TYPE] !== constants.MSG_SURVEY)
+    return;
   getParticipantId().then(function(participantId) {
     var record = new SurveySubmission.SurveyRecord(
         message['survey_type'],

--- a/extension/background.js
+++ b/extension/background.js
@@ -110,7 +110,7 @@ function setupState(details) {
  *   - If nothing is set locally, no work to do.
  *   - If either localStorage or syncStorage is set to CONSENT_REJECTED,
  *     uninstall the extension.
- *   - If there localStorage is set but syncStorage is not, set sync = local.
+ *   - If localStorage is set but syncStorage is not, set sync = local.
  *   - If syncStorage is still 'pending', set sync = local.
  * @returns {Promise} A promise that resolves when the CONSENT value is migrated
  */

--- a/extension/consent.js
+++ b/extension/consent.js
@@ -11,6 +11,7 @@ consentForm.status = constants.CONSENT_PENDING;
  * @param {string} newState The desired new state for the consent pref.
  */
 function setConsentStorageValue(newState) {
+  consentForm.status = newState;
   var items = {};
   items[constants.CONSENT_KEY] = newState;
   chrome.storage.sync.set(items);
@@ -84,3 +85,25 @@ function getInitialState() {
 }
 
 document.addEventListener('DOMContentLoaded', getInitialState);
+
+/**
+ * The sync'ed consent value has been updated. This might mean the user has
+ * given consent on another computer, and this window should be closed.
+ */
+function consentMaybeGrantedElsewhere(message) {
+  if (message[constants.MSG_TYPE] === constants.MSG_SURVEY)
+    return;
+
+  if (message[constants.MSG_TYPE] === constants.MSG_SETUP)
+    window.close();
+
+  if (message[constants.MSG_TYPE] !== constants.MSG_CONSENT)
+    return;
+
+  if (consentForm.status === constants.CONSENT_GRANTED ||
+      consentForm.status === constants.CONSENT_REJECTED)
+    return;
+
+  window.close();
+}
+chrome.runtime.onMessage.addListener(consentMaybeGrantedElsewhere);

--- a/extension/consent.js
+++ b/extension/consent.js
@@ -13,7 +13,7 @@ consentForm.status = constants.CONSENT_PENDING;
 function setConsentStorageValue(newState) {
   var items = {};
   items[constants.CONSENT_KEY] = newState;
-  chrome.storage.local.set(items);
+  chrome.storage.sync.set(items);
 }
 
 /**
@@ -80,7 +80,7 @@ function userRejectConsent(event) {
  */
 function getInitialState() {
   console.log('Consent page loading');
-  chrome.storage.local.get(constants.CONSENT_KEY, setupConsentForm);
+  chrome.storage.sync.get(constants.CONSENT_KEY, setupConsentForm);
 }
 
 document.addEventListener('DOMContentLoaded', getInitialState);

--- a/extension/consent.js
+++ b/extension/consent.js
@@ -101,8 +101,9 @@ function consentMaybeGrantedElsewhere(message) {
     return;
 
   if (consentForm.status === constants.CONSENT_GRANTED ||
-      consentForm.status === constants.CONSENT_REJECTED)
+      consentForm.status === constants.CONSENT_REJECTED) {
     return;
+  }
 
   window.close();
 }

--- a/extension/constants.js
+++ b/extension/constants.js
@@ -15,6 +15,12 @@ constants.SETUP_KEY = 'setup';  // Setup lookup key.
 constants.SETUP_PENDING = 'pending';
 constants.SETUP_COMPLETED = 'completed';
 
+// Constants for message passing.
+constants.MSG_TYPE = 'message_type';
+constants.MSG_CONSENT = 'consent_complete'; // Consent complete.
+constants.MSG_SETUP = 'setup_complete'; // Setup complete.
+constants.MSG_SURVEY = 'survey_complete';  // Survey finished.
+
 // The different types of survey questions that are possible.
 constants.QuestionType = {
   // Handled by the Fixed class.

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -11,6 +11,7 @@ setupSurvey.questions = [];
  * @param {string} newState The desired new state for the setup pref.
  */
 function setSetupStorageValue(newState) {
+  setupSurvey.status = newState;
   var items = {};
   items[constants.SETUP_KEY] = newState;
   chrome.storage.sync.set(items);
@@ -503,6 +504,7 @@ function setupFormSubmitted(event) {
   responses.push(os);
   chrome.runtime.sendMessage(
     {
+      'message_type': constants.MSG_SURVEY,
       'survey_type': constants.SurveyLocation.SETUP,
       'responses': responses
     }
@@ -525,3 +527,16 @@ function getInitialState() {
 }
 
 document.addEventListener('DOMContentLoaded', getInitialState);
+
+/**
+ * The sync'ed setup value has been updated. This might mean the user has
+ * done setup on another computer, and this window should be closed.
+ */
+function setupMaybeDoneElsewhere(message) {
+  if (message[constants.MSG_TYPE] !== constants.MSG_SETUP ||
+      setupSurvey.status === constants.SETUP_COMPLETED)
+    return;
+
+  window.close();
+}
+chrome.runtime.onMessage.addListener(setupMaybeDoneElsewhere);

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -534,8 +534,9 @@ document.addEventListener('DOMContentLoaded', getInitialState);
  */
 function setupMaybeDoneElsewhere(message) {
   if (message[constants.MSG_TYPE] !== constants.MSG_SETUP ||
-      setupSurvey.status === constants.SETUP_COMPLETED)
+      setupSurvey.status === constants.SETUP_COMPLETED) {
     return;
+  }
 
   window.close();
 }

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -13,7 +13,7 @@ setupSurvey.questions = [];
 function setSetupStorageValue(newState) {
   var items = {};
   items[constants.SETUP_KEY] = newState;
-  chrome.storage.local.set(items);
+  chrome.storage.sync.set(items);
 }
 
 /**
@@ -521,7 +521,7 @@ function setupFormSubmitted(event) {
  */
 function getInitialState() {
   console.log('Setup survey loading');
-  chrome.storage.local.get(constants.SETUP_KEY, setupSurveyForm);
+  chrome.storage.sync.get(constants.SETUP_KEY, setupSurveyForm);
 }
 
 document.addEventListener('DOMContentLoaded', getInitialState);

--- a/extension/surveys/driver.js
+++ b/extension/surveys/driver.js
@@ -159,6 +159,7 @@ function setupFormSubmitted(event) {
   }
   chrome.runtime.sendMessage(
     {
+      'message_type': constants.MSG_SURVEY,
       'survey_type': surveyDriver.surveyType,
       'responses': responses
     }


### PR DESCRIPTION
Dogfooders were complaining about two related things:
1) Consent survey popping up on all computers
2) Consent/setup values not propagated between computers
[ See #129 ]

This tries to fix that by doing the following things:
- All storage is now sync, not local.
- For existing users who are getting an update, migrate the important values from local to sync storage.
- When consent/setup happens on one device, it will close the consent form/setup survey on other devices.
