### PR TITLE
Caption should read "dialog" instead of "page" for extensions

### DIFF
--- a/extension/surveys/extension-noproceed.js
+++ b/extension/surveys/extension-noproceed.js
@@ -35,4 +35,9 @@ function setScreenshot() {
     default:
       $('example-img').src = 'screenshots/extension-win.png';
   }
+
+  // For extensions, we also want to update the caption.
+  $('saw-a-page').textContent =
+      'You just now saw a dialog like the one pictured above.';
 }
+

--- a/extension/surveys/extension-proceed.js
+++ b/extension/surveys/extension-proceed.js
@@ -35,4 +35,8 @@ function setScreenshot() {
     default:
       $('example-img').src = 'screenshots/extension-win.png';
   }
+
+  // For extensions, we also want to update the caption.
+  $('saw-a-page').textContent =
+      'You just now saw a dialog like the one pictured above.';
 }

--- a/extension/surveys/survey.html
+++ b/extension/surveys/survey.html
@@ -23,7 +23,7 @@
 
     <div class="centered hidden scroll-scroll" id="survey-container">
       <div class="alert centered inner-centering" id="instructions">
-        <p class="heavy">
+        <p class="heavy" id="saw-a-page">
           You just now saw a page like the one pictured above.
         </p>
         <p>The following questions are about that page.</p>


### PR DESCRIPTION
The caption text beneath the image should say "dialog" for extension installs. #108 
