### PR TITLE
Don't survey if user cancels inline install

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -341,9 +341,14 @@ function showSurveyNotification(element, decision) {
     case constants.EventType.MALWARE:
     case constants.EventType.PHISHING:
     case constants.EventType.EXTENSION_INSTALL:
-    case constants.EventType.EXTENSION_INLINE_INSTALL:
     case constants.EventType.EXTENSION_BUNDLE:
       // Supported events.
+      break;
+    case constants.EventType.EXTENSION_INLINE_INSTALL:
+      // Don't survey for an inline install if the user cancels.
+      // See https://github.com/GoogleChrome/experience-sampling/issues/74.
+      if (decision['name'] === constants.DecisionType.DENY)
+        return;
       break;
     case constants.EventType.HARMFUL:
     case constants.EventType.SB_OTHER:


### PR DESCRIPTION
As described in #74, clicking "View Details" on an inline install triggers the survey. This happens because we can't differentiate between "cancel" and "view details" -- both show up as a DENY event. To prevent this from happening, we won't survey on cancel for inline installs.