### PR TITLE
Record basic information about each event

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -508,12 +508,12 @@ function recordEvent(element, decision) {
   responses.push(new SurveySubmission.Response(
       'Learn more', decision['learn_more']));
   getParticipantId().then(function(participantId) {
-    var record = new SurveySubmission.SurveyRecord(
-      constants.FindEventType(element['name']),
-      participantId,
-      (new Date),
-      responses);
-    SurveySubmission.saveSurveyRecord(record);
+      var record = new SurveySubmission.SurveyRecord(
+        constants.FindEventType(element['name']),
+        participantId,
+        (new Date),
+        responses);
+      SurveySubmission.saveSurveyRecord(record);
   });
 }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -492,9 +492,35 @@ function loadSurvey(element, decision, timePromptShown, timePromptClicked) {
   });
 }
 
-// Trigger the new survey prompt when the participant makes a decision about an
-// experience sampling element.
+/**
+ * Record basic information about the event.
+ * @param {object} element The browser element of interest.
+ * @param {object} decision The decision the participant made.
+ */
+function recordEvent(element, decision) {
+  var responses = [];
+  responses.push(new SurveySubmission.Response(
+      'Full event type', element['name']));
+  responses.push(new SurveySubmission.Response(
+      'Response', decision['name']));
+  responses.push(new SurveySubmission.Response(
+      'Details', decision['details']));
+  responses.push(new SurveySubmission.Response(
+      'Learn more', decision['learn_more']));
+  getParticipantId().then(function(participantId) {
+    var record = new SurveySubmission.SurveyRecord(
+      constants.FindEventType(element['name']),
+      participantId,
+      (new Date),
+      responses);
+    SurveySubmission.saveSurveyRecord(record);
+  });
+}
+
+// Trigger the new survey prompt and record the event when the participant
+// makes a decision about an experience sampling element.
 chrome.experienceSamplingPrivate.onDecision.addListener(showSurveyNotification);
+chrome.experienceSamplingPrivate.onDecision.addListener(recordEvent);
 
 /**
  * Handle the submission of a completed survey.


### PR DESCRIPTION
This will record basic information about each event, every time an event fires, regardless of whether a notification is shown or the user uploads a survey. This lets us know how often events happen for the users in the study, but it does not upload the URL or any user survey responses.
