### PR TITLE
Only mark "I prefer not to answer" checkboxes as required

### DIFF
--- a/extension/constants.js
+++ b/extension/constants.js
@@ -46,8 +46,9 @@ constants.Randomize = {
   ANCHOR_LAST: 'anchorLast'  // Last element will stay in its place.
 };
 
-// Handle "other" specially.
+// Handle "other" and "I prefer not to answer" specially.
 constants.OTHER = 'Other: ';
+constants.NO_ANSWER = 'I prefer not to answer';
 
 // The different types of events that trigger survey notifications.
 // The strings need to match the definitions in Chrome.

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -44,7 +44,7 @@ function addQuestions(parentNode) {
         '45-54',
         '55-64',
         '65 or older',
-        'I prefer not to answer'        
+        constants.NO_ANSWER
       ],
       constants.Randomize.NONE);
   addQuestion(parentNode, age);
@@ -57,7 +57,7 @@ function addQuestions(parentNode) {
         'Female',
         'Male',
         constants.OTHER,
-        'I prefer not to answer'
+        constants.NO_ANSWER
       ],
       constants.Randomize.NONE);
   addQuestion(parentNode, gender);
@@ -75,7 +75,7 @@ function addQuestions(parentNode) {
         'Bachelors degree (for example, BS, BA)',
         'Graduate degree',
         constants.OTHER,
-        'I prefer not to answer'
+        constants.NO_ANSWER
       ],
       constants.Randomize.NONE);
   addQuestion(parentNode, education);
@@ -415,7 +415,7 @@ function addQuestions(parentNode) {
         'My school\'s',
         'A library\'s',
         constants.OTHER,
-        'I prefer not to answer'
+        constants.NO_ANSWER
       ],
       constants.Randomize.NONE);
   addQuestion(parentNode, computerOwner);
@@ -429,7 +429,7 @@ function addQuestions(parentNode) {
         'Yes',
         'No',
         'I don\'t know',
-        'I prefer not to answer'
+        constants.NO_ANSWER
       ],
       constants.Randomize.NONE);
   addQuestion(parentNode, antivirus);

--- a/extension/surveys/common-questions.js
+++ b/extension/surveys/common-questions.js
@@ -187,7 +187,7 @@ commonQuestions.createAccountQuestion = function() {
       constants.QuestionType.RADIO,
       'Do you have an account on ' + surveyDriver.questionUrl + '?',
       true,
-      ['Yes', 'No', 'I\'m not sure', 'I prefer not to answer'],
+      ['Yes', 'No', 'I\'m not sure', constants.NO_ANSWER],
       constants.Randomize.ANCHOR_LAST);
   account.setPlaceholder('Do you have an account on [URL]?');
   return account;
@@ -203,7 +203,7 @@ commonQuestions.createVisitQuestion = function() {
       'Were you trying to visit ' + surveyDriver.questionUrl +
            ' when you saw the page instead?',
       true,
-      ['Yes', 'No', 'I\'m not sure', 'I prefer not to answer'],
+      ['Yes', 'No', 'I\'m not sure', constants.NO_ANSWER],
       constants.Randomize.ANCHOR_LAST);
   visit.setPlaceholder('Were you trying to visit [URL] when you saw the page ' +
       'instead?');

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -119,14 +119,20 @@ FixedQuestion.prototype.makeDOMTree = function() {
             elems[i].removeEventListener('click', removeRequired);
           }
         };
-        if (this.required) {
-          input.setAttribute('required', this.required);
-          if (this.questionType === constants.QuestionType.CHECKBOX) {
-            // By default, HTML5 requires *all* of the checkboxes to be checked
-            // for submission. Since we only want one of a group to be
-            // submitted, remove the requirement once one is checked.
-            input.addEventListener('change', removeRequired);
+        if (this.required && constants.QuestionType.CHECKBOX) {
+          // Remove the requirement once one is checked.
+          input.addEventListener('change', removeRequired);
+          // If there is a "prefer not to answer" option, mark that one as
+          // required but leave the others alone. If there isn't, mark them
+          // all as required.
+          if (this.answers[i] === constants.NO_ANSWER) {
+            input.setAttribute('required', this.required);
+          } else if (this.answers[this.answers.length - 1] !=
+                     constants.NO_ANSWER) {
+            input.setAttribute('required', this.required);
           }
+        } else if (this.required) {
+          input.setAttribute('required', this.required);
         }
         answer.appendChild(input);
 


### PR DESCRIPTION
Questions with checkboxes may have required answers.
* If the set of checkboxes include "I prefer not to answer", that should be the required checkbox.
* Otherwise, all checkboxes will be required (although as soon as someone checks any one of them, that is lifted).

Fixes #121 