### PR TITLE
Improve form width CSS

### DIFF
--- a/extension/surveys/survey-style.css
+++ b/extension/surveys/survey-style.css
@@ -26,9 +26,14 @@
   color: #4285F4;
 }
 
+#survey-form {
+  margin: 0 auto;
+  width: 100%;
+}
+
 .centered {
   margin: 0 auto;
-  width: 80%;
+  width: 90%;
 }
 
 .clear-div {
@@ -46,6 +51,7 @@
 }
 
 #explanation {
+  max-width: 600px;
   padding-bottom: 20px;
 }
 
@@ -53,7 +59,11 @@
   background-color: #ECF3FE;
   border: none;
   margin-bottom: 1em;
-  padding: 8px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 3%;
+  padding-right: 3%;
+  min-width: 900px;
 }
 
 .first-rowlabel {
@@ -134,7 +144,7 @@ p {
   bottom: 0;
   border: 1px solid #B8B8B8;
   left: 0;
-  overflow-x: hidden;
+  overflow-x: auto;
   overflow-y: scroll;
   position: absolute;
   right: 0;
@@ -152,7 +162,7 @@ p {
 }
 
 ::-webkit-scrollbar {
-    width: 12px;
+  width: 12px;
 }
  
 ::-webkit-scrollbar-track {

--- a/extension/surveys/survey-style.css
+++ b/extension/surveys/survey-style.css
@@ -59,11 +59,11 @@
   background-color: #ECF3FE;
   border: none;
   margin-bottom: 1em;
-  padding-top: 8px;
+  min-width: 900px;
   padding-bottom: 8px;
   padding-left: 3%;
   padding-right: 3%;
-  min-width: 900px;
+  padding-top: 8px;
 }
 
 .first-rowlabel {


### PR DESCRIPTION
As Chris pointed out in #126, the survey forms did not scale gracefully as the window changed shape. This improves the form's appearance at different sizes. Maybe not quite as pretty but def easier to use.

Screenshots:

![screen shot 2015-01-16 at 2 33 19 pm](https://cloud.githubusercontent.com/assets/4962198/5785647/fe42961c-9d8d-11e4-9231-f9995e686a60.png)
![screen shot 2015-01-16 at 2 33 31 pm](https://cloud.githubusercontent.com/assets/4962198/5785650/03bd90e2-9d8e-11e4-8dd8-f8a37237198c.png)
![screen shot 2015-01-16 at 2 33 39 pm](https://cloud.githubusercontent.com/assets/4962198/5785652/05e2fa88-9d8e-11e4-8006-bcdd17a60bdf.png)

Fixes #126
