### PR TITLE
Changes to export.py to make it easier to parse JSON output files

### DIFF
--- a/backend/export.py
+++ b/backend/export.py
@@ -76,14 +76,17 @@ class ExportWorker(webapp2.RequestHandler):
         query = SurveyModel.query()
         cursor = None
         more = True
-        delim = ''
+        delim = ',\n'
+        f.write('[')
         while more:
           records, cursor, more = query.fetch_page(50, start_cursor=cursor)
           gc.collect()
-          for record in records:
+          if records:
+            f.write(json.dumps(records[0].to_dict(), cls=ModelEncoder))
+          for record in records.[1:]:
             f.write(delim)
             f.write(json.dumps(record.to_dict(), cls=ModelEncoder))
-          delim = ',\n'
+          f.write(']')
 
     export_data(filename)
 

--- a/backend/export.py
+++ b/backend/export.py
@@ -83,7 +83,7 @@ class ExportWorker(webapp2.RequestHandler):
           gc.collect()
           if records:
             f.write(json.dumps(records[0].to_dict(), cls=ModelEncoder))
-          for record in records.[1:]:
+          for record in records[1:]:
             f.write(delim)
             f.write(json.dumps(record.to_dict(), cls=ModelEncoder))
           f.write(']')

--- a/backend/export.py
+++ b/backend/export.py
@@ -86,7 +86,7 @@ class ExportWorker(webapp2.RequestHandler):
           for record in records[1:]:
             f.write(delim)
             f.write(json.dumps(record.to_dict(), cls=ModelEncoder))
-          f.write(']')
+        f.write(']')
 
     export_data(filename)
 

--- a/backend/export.py
+++ b/backend/export.py
@@ -76,16 +76,15 @@ class ExportWorker(webapp2.RequestHandler):
         query = SurveyModel.query()
         cursor = None
         more = True
-        delim = ',\n'
+        delim = ''
         f.write('[')
         while more:
           records, cursor, more = query.fetch_page(50, start_cursor=cursor)
           gc.collect()
-          if records:
-            f.write(json.dumps(records[0].to_dict(), cls=ModelEncoder))
-          for record in records[1:]:
+          for record in records:
             f.write(delim)
             f.write(json.dumps(record.to_dict(), cls=ModelEncoder))
+            delim = ',\n'
         f.write(']')
 
     export_data(filename)


### PR DESCRIPTION
@adrifelt When I deployed this to App Engine, it broke our export page at https://chrome-experience-sampling.appspot.com/export. When I rolled back, page was still broken. Know what's up?