### PR TITLE
Uninstall if the user doesn't give an age or is under 18

### DIFF
--- a/extension/setup.js
+++ b/extension/setup.js
@@ -502,8 +502,14 @@ function setupFormSubmitted(event) {
 
   // Check whether the participant is underage.
   var ageQuestion = document['survey-form']['Whatisyourage'];
-  if (ageQuestion.value === '0-17yearsoldoryounger') {
+  if (ageQuestion.value === '0-17yearsoldoryounger-Whatisyourage') {
     chrome.management.uninstallSelf();
+    return;
+  } else if (ageQuestion.value === '7-Iprefernottoanswer-Whatisyourage') {
+    var provideAge = confirm(
+        "We need to know your age to make sure you're over 18.");
+    if (!provideAge)  // User did not click "OK".
+      chrome.management.uninstallSelf();
     return;
   }
 

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -506,10 +506,11 @@ function setupFormSubmitted(event) {
     chrome.management.uninstallSelf();
     return;
   } else if (ageQuestion.value === '7-Iprefernottoanswer-Whatisyourage') {
-    var provideAge = confirm(
-        "We need to know your age to make sure you're over 18.");
-    if (!provideAge)  // User did not click "OK".
+    if (!confirm("We need to know your approximate age to make sure you're " +
+        "over 18.")) {
+      // User did not click "OK".
       chrome.management.uninstallSelf();
+    }
     return;
   }
 


### PR DESCRIPTION
The extension should be uninstalled if the user doesn't give an age or is under 18.

If the user doesn't give an age, show a confirm prompt to ask the user to add an age. If the user clicks "OK" then they can add an age. If they click "Cancel", the extension is uninstalled.

Fixes #145 
