### PR TITLE
Fix survey submission bug

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -509,9 +509,9 @@ function recordEvent(element, decision) {
   responses.push(new SurveySubmission.Response(
       'Response', decision['name']));
   responses.push(new SurveySubmission.Response(
-      'Details', decision['details']));
+      'Details', decision['details'].toString()));
   responses.push(new SurveySubmission.Response(
-      'Learn more', decision['learn_more']));
+      'Learn more', decision['learn_more'].toString()));
   getParticipantId().then(function(participantId) {
       var record = new SurveySubmission.SurveyRecord(
         constants.FindEventType(element['name']),

--- a/extension/survey-submission.js
+++ b/extension/survey-submission.js
@@ -27,6 +27,10 @@ SurveySubmission.QUEUE_ALARM_NAME = 'surveySubmissionAlarm';
 SurveySubmission.Response = function(question, answer) {
   this.question = question;
   this.answer = answer;
+  if (typeof this.question !== "string")
+    console.error(JSON.stringify(question) + " is not a string!");
+  if (typeof this.answer !== "string")
+    console.error(JSON.stringify(question) + " is not a string!");
 }
 
 /**

--- a/extension/survey-submission.js
+++ b/extension/survey-submission.js
@@ -28,9 +28,9 @@ SurveySubmission.Response = function(question, answer) {
   this.question = question;
   this.answer = answer;
   if (typeof this.question !== "string")
-    console.error(JSON.stringify(question) + " is not a string!");
+    console.error(JSON.stringify(this.question) + " is not a string!");
   if (typeof this.answer !== "string")
-    console.error(JSON.stringify(question) + " is not a string!");
+    console.error(JSON.stringify(this.answer) + " is not a string!");
 }
 
 /**


### PR DESCRIPTION
The backend expects that all of the "answer" fields will be a string, but these values are booleans. Converting them to strings to avoid rejection.

Fixes #118 
