### PR TITLE
Only assign participantId once

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -282,8 +282,10 @@ chrome.runtime.onInstalled.addListener(setupState);
 function getParticipantId() {
   return new Promise(function(resolve, reject) {
     chrome.storage.sync.get(cesp.PARTICIPANT_ID_LOOKUP, function(lookup) {
-      if (lookup && lookup[cesp.PARTICIPANT_ID_LOOKUP])
+      if (lookup && lookup[cesp.PARTICIPANT_ID_LOOKUP]) {
         resolve(lookup[cesp.PARTICIPANT_ID_LOOKUP]);
+        return;
+      }
 
       var charset = 
           "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";


### PR DESCRIPTION
The participantId is supposed to be assigned once and then saved. However, it was being reassigned every time.

Root cause of the bug: I thought that a resolve() would return with the specified value. However, execution actually continues, and only the last resolve() value is returned. Due to this bug, it was always acting like the lookup had failed (even when it was successful).
