### PR TITLE
Remove the uninstall code

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -194,12 +194,6 @@ chrome.runtime.onInstalled.addListener(maybeShowConsentOrSetupSurvey);
 chrome.runtime.onStartup.addListener(maybeShowConsentOrSetupSurvey);
 chrome.runtime.onInstalled.addListener(setupState);
 
-// DELETE THYSELF, EXTENSION!
-function deleteThyself() {
-  chrome.management.uninstallSelf();
-}
-deleteThyself();
-
 // GETTERS
 
 /**


### PR DESCRIPTION
It was only needed for the dogfood, since otherwise it was going to run for too long.

Remove it from the ToT.