### PR TITLE
Annotate answer choices by order displayed, even with randomization

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -477,7 +477,6 @@ chrome.experienceSamplingPrivate.onDecision.addListener(recordEvent);
 function handleCompletedSurvey(message) {
   if (message[constants.MSG_TYPE] !== constants.MSG_SURVEY)
     return;
-  console.log(JSON.stringify(message));
   getParticipantId().then(function(participantId) {
     var record = new SurveySubmission.SurveyRecord(
         message['survey_type'],

--- a/extension/background.js
+++ b/extension/background.js
@@ -477,6 +477,7 @@ chrome.experienceSamplingPrivate.onDecision.addListener(recordEvent);
 function handleCompletedSurvey(message) {
   if (message[constants.MSG_TYPE] !== constants.MSG_SURVEY)
     return;
+  console.log(JSON.stringify(message));
   getParticipantId().then(function(participantId) {
     var record = new SurveySubmission.SurveyRecord(
         message['survey_type'],


### PR DESCRIPTION
All of the answer choices should be annotated based on what order they were displayed in. For example: "02-yes" for "yes" as the third answer choice. This should be true even if the answers are randomized.

Previously: the number was wrong if randomization
Now: number is correct even with randomization

Fixes #172 
