### PR TITLE
Remove unneeded permissions

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,12 +13,10 @@
   "permissions": [
     "alarms",
     "experienceSamplingPrivate",
-    "identity",
     "notifications",
     "storage",
     "unlimitedStorage",
-    "https://chrome-experience-sampling.appspot.com/_ah/api/*",
-    "https://www.google.com/*"
+    "https://chrome-experience-sampling.appspot.com/_ah/api/*"
   ],
 
   "icons": {


### PR DESCRIPTION
I added these permissions back when I thought we were going to be asking identity questions. Since we aren't, the permissions are no longer needed.
