### PR TITLE
Prompt before closing survey

### DIFF
--- a/extension/consent.js
+++ b/extension/consent.js
@@ -84,6 +84,7 @@ function getInitialState() {
   console.log('Consent page loading');
   chrome.storage.sync.get(constants.CONSENT_KEY, setupConsentForm);
 }
+
 document.addEventListener('DOMContentLoaded', getInitialState);
 
 /**

--- a/extension/consent.js
+++ b/extension/consent.js
@@ -84,7 +84,6 @@ function getInitialState() {
   console.log('Consent page loading');
   chrome.storage.sync.get(constants.CONSENT_KEY, setupConsentForm);
 }
-
 document.addEventListener('DOMContentLoaded', getInitialState);
 
 /**

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -5,7 +5,7 @@
 var setupSurvey = {};  // Namespace variable
 setupSurvey.status = constants.SETUP_PENDING;
 setupSurvey.questions = [];
-setupSurvey.completionStatus = false;  // Whether the user submitted the form.
+setupSurvey.isSubmitted = false;  // Whether the user submitted the form.
 
 
 /**
@@ -501,7 +501,7 @@ function setupSurveyForm(savedState) {
  */
 function setupFormSubmitted(event) {
   event.preventDefault();
-  setupSurvey.completionStatus = true;
+  setupSurvey.isSubmitted = true;
 
   // Check whether the participant is underage.
   var ageQuestion = document['survey-form']['Whatisyourage'];
@@ -566,7 +566,7 @@ chrome.runtime.onMessage.addListener(setupMaybeDoneElsewhere);
  * @param {object} event The window close event.
  */
 function promptOnClose(event) {
-  if (setupSurvey.completionStatus) return;
+  if (setupSurvey.isSubmitted) return;
   if (!formHasContent($('survey-form'))) return;
 
   event.returnValue = "Oops! Closing now will throw away your answers.";

--- a/extension/setup.js
+++ b/extension/setup.js
@@ -5,6 +5,8 @@
 var setupSurvey = {};  // Namespace variable
 setupSurvey.status = constants.SETUP_PENDING;
 setupSurvey.questions = [];
+setupSurvey.completionStatus = false;  // Whether the user submitted the form.
+
 
 /**
  * A helper method for updating the value in local storage.
@@ -499,6 +501,7 @@ function setupSurveyForm(savedState) {
  */
 function setupFormSubmitted(event) {
   event.preventDefault();
+  setupSurvey.completionStatus = true;
 
   // Check whether the participant is underage.
   var ageQuestion = document['survey-form']['Whatisyourage'];
@@ -557,3 +560,15 @@ function setupMaybeDoneElsewhere(message) {
   window.close();
 }
 chrome.runtime.onMessage.addListener(setupMaybeDoneElsewhere);
+
+/**
+ * Prompt the user on close, if the form has been started but not yet submitted.
+ * @param {object} event The window close event.
+ */
+function promptOnClose(event) {
+  if (setupSurvey.completionStatus) return;
+  if (!formHasContent($('survey-form'))) return;
+
+  event.returnValue = "Oops! Closing now will throw away your answers.";
+}
+window.addEventListener('beforeunload', promptOnClose);

--- a/extension/surveys/driver.js
+++ b/extension/surveys/driver.js
@@ -143,7 +143,7 @@ function setupSurvey() {
 
 /**
  * Handles the submission of the setup survey.
- * @param {object} The submission button click event.
+ * @param {object} event The submission button click event.
  */
 function setupFormSubmitted(event) {
   event.preventDefault();
@@ -171,9 +171,13 @@ function setupFormSubmitted(event) {
   $('thank-you').classList.remove('hidden');
   setTimeout(window.close, constants.SURVEY_CLOSE_TIME);
 }
-
 document.addEventListener('DOMContentLoaded', loadSurveyScript);
 
+/**
+ * Checks whether a form has any responses or text in it.
+ * @param {object} form The form to check.
+ * @returns {boolean} True if the form has content.
+ */
 function formHasContent(form) {
   for (var i = 0; i < form.elements.length; i++) {
     var element = form.elements[i];
@@ -211,6 +215,10 @@ function formHasContent(form) {
   return false;
 }
 
+/**
+ * Prompt the user on close, if the form has been started but not yet submitted.
+ * @param {object} event The window close event.
+ */
 function promptOnClose(event) {
   if (surveyDriver.completionStatus) return;
   if (!formHasContent($('survey-form'))) return;

--- a/extension/surveys/driver.js
+++ b/extension/surveys/driver.js
@@ -3,7 +3,7 @@ surveyDriver.surveyType = '';  // Holds the type of survey.
 surveyDriver.questionUrl = '';  // Holds the URL for putting into questions.
 surveyDriver.questions = [];  // Holds the questions for a given survey.
 surveyDriver.operatingSystem = ''; // mac, win, cros, or linux
-surveyDriver.completionStatus = false;  // Whether the user submitted the form.
+surveyDriver.isSubmitted = false;  // Whether the user submitted the form.
 
 /**
  * Convenience method for adding questions.
@@ -148,7 +148,7 @@ function setupSurvey() {
 function setupFormSubmitted(event) {
   event.preventDefault();
 
-  surveyDriver.completionStatus = true;
+  surveyDriver.isSubmitted = true;
   var responses = getFormValues(
       surveyDriver.questions, document['survey-form']);
   var urlConsentQ = commonQuestions.createRecordUrlQuestion();
@@ -178,7 +178,7 @@ document.addEventListener('DOMContentLoaded', loadSurveyScript);
  * @param {object} event The window close event.
  */
 function promptOnClose(event) {
-  if (surveyDriver.completionStatus) return;
+  if (surveyDriver.isSubmitted) return;
   if (!formHasContent($('survey-form'))) return;
 
   event.returnValue = "Oops! Closing now will throw away your answers.";

--- a/extension/surveys/driver.js
+++ b/extension/surveys/driver.js
@@ -174,48 +174,6 @@ function setupFormSubmitted(event) {
 document.addEventListener('DOMContentLoaded', loadSurveyScript);
 
 /**
- * Checks whether a form has any responses or text in it.
- * @param {object} form The form to check.
- * @returns {boolean} True if the form has content.
- */
-function formHasContent(form) {
-  for (var i = 0; i < form.elements.length; i++) {
-    var element = form.elements[i];
-    switch (element.type) {
-      case 'checkbox':
-      case 'radio':
-        if (element.checked)
-          return true;
-        break;
-      case 'text':
-      case 'password':
-      case 'number':
-      case 'date':
-      case 'color':
-      case 'range':
-      case 'month':
-      case 'week':
-      case 'time':
-      case 'datetime':
-      case 'datetime-local':
-      case 'email':
-      case 'search':
-      case 'tel':
-      case 'url':
-      case 'textarea':
-      case 'select':
-        if (element.value !== '')
-          return true;
-        break;
-      case 'submit':
-      case 'button':
-        break;
-    }
-  }
-  return false;
-}
-
-/**
  * Prompt the user on close, if the form has been started but not yet submitted.
  * @param {object} event The window close event.
  */
@@ -223,6 +181,6 @@ function promptOnClose(event) {
   if (surveyDriver.completionStatus) return;
   if (!formHasContent($('survey-form'))) return;
 
-  event.returnValue = "Closing now will throw away your answers.";
+  event.returnValue = "Oops! Closing now will throw away your answers.";
 }
 window.addEventListener('beforeunload', promptOnClose);

--- a/extension/surveys/driver.js
+++ b/extension/surveys/driver.js
@@ -3,6 +3,7 @@ surveyDriver.surveyType = '';  // Holds the type of survey.
 surveyDriver.questionUrl = '';  // Holds the URL for putting into questions.
 surveyDriver.questions = [];  // Holds the questions for a given survey.
 surveyDriver.operatingSystem = ''; // mac, win, cros, or linux
+surveyDriver.completionStatus = false;  // Whether the user submitted the form.
 
 /**
  * Convenience method for adding questions.
@@ -147,6 +148,7 @@ function setupSurvey() {
 function setupFormSubmitted(event) {
   event.preventDefault();
 
+  surveyDriver.completionStatus = true;
   var responses = getFormValues(
       surveyDriver.questions, document['survey-form']);
   var urlConsentQ = commonQuestions.createRecordUrlQuestion();
@@ -171,3 +173,48 @@ function setupFormSubmitted(event) {
 }
 
 document.addEventListener('DOMContentLoaded', loadSurveyScript);
+
+function formHasContent(form) {
+  for (var i = 0; i < form.elements.length; i++) {
+    var element = form.elements[i];
+    switch (element.type) {
+      case 'checkbox':
+      case 'radio':
+        if (element.checked)
+          return true;
+        break;
+      case 'text':
+      case 'password':
+      case 'number':
+      case 'date':
+      case 'color':
+      case 'range':
+      case 'month':
+      case 'week':
+      case 'time':
+      case 'datetime':
+      case 'datetime-local':
+      case 'email':
+      case 'search':
+      case 'tel':
+      case 'url':
+      case 'textarea':
+      case 'select':
+        if (element.value !== '')
+          return true;
+        break;
+      case 'submit':
+      case 'button':
+        break;
+    }
+  }
+  return false;
+}
+
+function promptOnClose(event) {
+  if (surveyDriver.completionStatus) return;
+  if (!formHasContent($('survey-form'))) return;
+
+  event.returnValue = "Closing now will throw away your answers.";
+}
+window.addEventListener('beforeunload', promptOnClose);

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -571,3 +571,45 @@ function getFormValues(questionArr, form) {
   }
   return responses;
 }
+
+/**
+ * Checks whether a form has any responses or text in it.
+ * @param {object} form The form to check.
+ * @returns {boolean} True if the form has content.
+ */
+function formHasContent(form) {
+  for (var i = 0; i < form.elements.length; i++) {
+    var element = form.elements[i];
+    switch (element.type) {
+      case 'checkbox':
+      case 'radio':
+        if (element.checked)
+          return true;
+        break;
+      case 'text':
+      case 'password':
+      case 'number':
+      case 'date':
+      case 'color':
+      case 'range':
+      case 'month':
+      case 'week':
+      case 'time':
+      case 'datetime':
+      case 'datetime-local':
+      case 'email':
+      case 'search':
+      case 'tel':
+      case 'url':
+      case 'textarea':
+      case 'select':
+        if (element.value !== '')
+          return true;
+        break;
+      case 'submit':
+      case 'button':
+        break;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Show a prompt if the user tries to close a non-empty survey without having hit the 'submit' button.

Resolves #199 and #196. Applies to both the setup survey and actual surveys.
