### PR TITLE
Extension caption should always refer to 'dialog'

### DIFF
--- a/extension/surveys/extension-noproceed.js
+++ b/extension/surveys/extension-noproceed.js
@@ -39,5 +39,7 @@ function setScreenshot() {
   // For extensions, we also want to update the caption.
   $('saw-a-page').textContent =
       'You just now saw a dialog like the one shown above.';
+  $('following-questions').textContent =
+      'The following questions are about that dialog.';
 }
 

--- a/extension/surveys/extension-proceed.js
+++ b/extension/surveys/extension-proceed.js
@@ -39,4 +39,6 @@ function setScreenshot() {
   // For extensions, we also want to update the caption.
   $('saw-a-page').textContent =
       'You just now saw a dialog like the one shown above.';
+  $('following-questions').textContent =
+      'The following questions are about that dialog.';
 }

--- a/extension/surveys/survey.html
+++ b/extension/surveys/survey.html
@@ -26,7 +26,9 @@
         <p class="heavy" id="saw-a-page">
           You just now saw a page like the one shown above.
         </p>
-        <p>The following questions are about that page.</p>
+        <p id="following-questions">
+          The following questions are about that page.
+        </p>
       </div>
       <form name="survey-form" id="survey-form"></form>
     </div>


### PR DESCRIPTION
The extension caption should always refer to the 'dialog', never to the 'page'. Fixes #209 