### PR TITLE
Make multiple checked checkboxes only return one answer as a list; test ...

### DIFF
--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -542,11 +542,12 @@ function getFormValues(questionArr, form) {
       // Checkboxes may have multiple answers.
       var answerList = document.querySelectorAll(
           'input[name="' + questionLookup + '"]:checked');
-      for (var j = 0; j < answerList.length; j++) {
-        var response = new SurveySubmission.Response(
-            questionStr, answerList[j].value || 'NOANSWER');
-        responses.push(response);
+      var answer = answerList[0].value || 'NOANSWER';
+      for (var j = 1; j < answerList.length; j++) {
+        answer = answer.concat(",", answerList[j].value)
       }
+      var response = new SurveySubmission.Response(questionStr, answer);
+      responses.push(response);
     } else if (question.questionType ===
                constants.QuestionType.MULT_HORIZ_SCALE) {
       // MULT_HOR_SCALE questions have multiple levels of responses.

--- a/tools/processresults.py
+++ b/tools/processresults.py
@@ -24,9 +24,11 @@ TECHFAMILIAR_QUESTION_PREFIX = ('How familiar are you with each of the '
 ATTRIBUTE_QUESTION_PREFIX = 'To what degree do each of the following'
 
 
-def ProcessResults(json_in_file, csv_prefix,
-                   start_date = FRIENDS_AND_FAMILY_BETA_DATE,
-                   demographic_start_date = FRIENDS_AND_FAMILY_BETA_DATE):
+def ProcessResults(
+    json_in_file,
+    csv_prefix,
+    filter_items_before_date = FRIENDS_AND_FAMILY_BETA_DATE,
+    filter_demographic_items_before_date = FRIENDS_AND_FAMILY_BETA_DATE):
   """Take results from AppEngine JSON file, process, and write to CSV file.
 
   Results from the input JSON file will be filtered into the 9 experimental
@@ -50,11 +52,11 @@ def ProcessResults(json_in_file, csv_prefix,
   demo_results, parsed_events = _ParseSurveyResults(json_in_file)
 
   demo_results, demo_index = _FilterDemographicResults(
-      demo_results, demographic_start_date)
+      demo_results, filter_demographic_items_before_date)
   _WriteToCsv(demo_results, demo_index, csv_prefix +
               DEMOGRAPHIC_CSV_PREFIX + '.csv')
 
-  parsed_events = _DiscardResultsBeforeDate(parsed_events, start_date)
+  parsed_events = _DiscardResultsBeforeDate(parsed_events, filter_items_before_date)
 
   for c in CONDITIONS:
     try:

--- a/tools/processresults_test.py
+++ b/tools/processresults_test.py
@@ -37,7 +37,6 @@ class TestProcessResults(unittest.TestCase):
                     csv_headers)
 
       test_line = csv_file.readline()
-      print test_line
       self.assertIn(('P2DA1,"0-Female-Whatisyourgender,'
                      '1-Male-Whatisyourgender,2-Other-Whatisyourgender",'
                      'P2DendoPortAnswer,P2TCPIPAnswer'), test_line)

--- a/tools/processresults_test.py
+++ b/tools/processresults_test.py
@@ -12,29 +12,35 @@ import os
 import unittest
 
 class TestProcessResults(unittest.TestCase):
-  
+
   def setUp(self):
     with open('processresults_test_input.json', 'r') as json_file:
       self.mock_results = json.load(json_file)
-    
+
   def test_ProcessResults_creates_three_csv_files_with_expected_data(self):
     processresults.ProcessResults('processresults_test_input.json',
-                                  'processresults_test_')
+                                  'processresults_test_',
+                                  processresults.DOGFOOD_START_DATE,
+                                  processresults.DEMOGRAPHIC_STABLE_DATE)
 
     metadata_headers = ('date_received,date_taken,participant_id,survey_type')
     with open('processresults_test_demographics.csv') as csv_file:
       csv_headers = csv_file.readline()
       self.assertIn(metadata_headers, csv_headers)
       self.assertIn('What is your age?', csv_headers)
+      self.assertIn('What is your gender?', csv_headers)
       self.assertIn(('How familiar are you with each of the following computer '
                      'and Internet-related items? I have...(DendoPort)'),
                     csv_headers)
       self.assertIn(('How familiar are you with each of the following computer '
                      'and Internet-related items? I have...(TCP/IP)'),
                     csv_headers)
-      
+
       test_line = csv_file.readline()
-      self.assertIn('P2DA1,P2DendoPortAnswer,P2TCPIPAnswer', test_line)
+      print test_line
+      self.assertIn(('P2DA1,"0-Female-Whatisyourgender,'
+                     '1-Male-Whatisyourgender,2-Other-Whatisyourgender",'
+                     'P2DendoPortAnswer,P2TCPIPAnswer'), test_line)
 
     with open('processresults_test_ssl-overridable-proceed.csv') as csv_file:
       csv_headers = csv_file.readline()
@@ -46,7 +52,7 @@ class TestProcessResults(unittest.TestCase):
                      'adjectives describe this page?(B),'
                      'To what degree do each of the following '
                      'adjectives describe this page?(C),Q7,URL'), csv_headers)
-      
+
       test_line = csv_file.readline()
       self.assertIn('P2A1,P2A2,P2A3,P2AttributeAAnswer,'
                     'P2AttributeBAnswer,P2AttributeCAnswer,P2A7', test_line)
@@ -68,7 +74,7 @@ class TestProcessResults(unittest.TestCase):
       test_line = csv_file.readline()
       self.assertIn('P4A1,P4A2,P4A3,P4AttributeAAnswer,'
                     'P4AttributeBAnswer,P4AttributeCAnswer,P4A7', test_line)
-              
+
   def test__DiscardResultsBeforeDate_filters_out_two_november_dates(self):
     results = [r for r in self.mock_results
                if r['survey_type'] != 'setup.js']
@@ -79,7 +85,7 @@ class TestProcessResults(unittest.TestCase):
     self.assertEqual(results[0]['date_taken'], u'2015-01-05T11:48:39.760000')
     self.assertEqual(results[1]['date_taken'], u'2015-01-05T00:00:00.123456')
     self.assertEqual(results[2]['date_taken'], u'2015-01-05T01:02:03.123456')
-    
+
   def test__FilterByCondition_filters_out_two_malware_noproceed(self):
     results = self.mock_results
     results = processresults._FilterByCondition('ssl-overridable-proceed',
@@ -97,7 +103,7 @@ class TestProcessResults(unittest.TestCase):
 
     self.assertEqual(len(results), 1)
     self.assertNotEqual(results[0]['responses'][0]['question'], 'PLACEHOLDER')
-        
+
   def test__CanonicalizeQuestions_reorders_attribute_questions(self):
     results = [r for r in self.mock_results
                if r['survey_type'] == 'ssl-overridable-proceed.js']
@@ -116,8 +122,8 @@ class TestProcessResults(unittest.TestCase):
       self.assertEqual(
           r['responses'][5]['question'],
           ('To what degree do each of the following adjectives '
-          'describe this page?(C)'))            
-    
+          'describe this page?(C)'))
+
   def test__CanonicalizeQuestions_replaces_urls_with_placeholder(self):
     results = [r for r in self.mock_results
                if r['survey_type'] == 'ssl-overridable-proceed.js']
@@ -125,8 +131,9 @@ class TestProcessResults(unittest.TestCase):
 
     for r in results:
       self.assertEqual(
-          r['responses'][0]['question'], 'blah "[CHOSEN]" "[ALTERNATIVE]." blah')
-  
+          r['responses'][0]['question'],
+          'blah "[CHOSEN]" "[ALTERNATIVE]." blah')
+
   def test__CanonicalizeQuestions_returns_canonical_index(self):
     results = [r for r in self.mock_results
                if r['survey_type'] == 'ssl-overridable-proceed.js']
@@ -134,7 +141,7 @@ class TestProcessResults(unittest.TestCase):
 
     # 2nd item (index 1) in mock_results should be selected as canonical
     self.assertEqual(canonical_index, 1)
-  
+
   def test__CanonicalizeQuestions_raises_exception_on_nonequal_questions(self):
     results = [r for r in self.mock_results
                if r['survey_type'] != 'setup.js']
@@ -158,20 +165,20 @@ class TestProcessResults(unittest.TestCase):
 
     self.assertEqual(len(results), 1)
     self.assertEqual(
-        results[0]['responses'][1]['question'],
+        results[0]['responses'][2]['question'],
         ('How familiar are you with each of the following computer and '
          'Internet-related items? I have...(DendoPort)'))
     self.assertEqual(
-        results[0]['responses'][2]['question'],
+        results[0]['responses'][3]['question'],
         ('How familiar are you with each of the following computer and '
          'Internet-related items? I have...(TCP/IP)'))
-    
+
   def tearDown(self):
     try:
       os.remove('processresults_test_ssl-overridable-proceed.csv')
       os.remove('processresults_test_malware-noproceed.csv')
     except OSError:
       pass
-        
+
 if __name__ == '__main__':
   unittest.main()

--- a/tools/processresults_test_input.json
+++ b/tools/processresults_test_input.json
@@ -192,6 +192,10 @@
         "question": "What is your age?"
       },
       {
+        "answer": "0-Female-Whatisyourgender",
+        "question": "What is your gender?"
+      },
+      {
         "answer": "P1TCPIPAnswer",
         "question": "How familiar are you with each of the following computer and Internet-related items? I have...(TCP/IP)"
       },
@@ -210,6 +214,10 @@
       {
         "answer": "P2DA1",
         "question": "What is your age?"
+      },
+      {
+        "answer": "0-Female-Whatisyourgender,1-Male-Whatisyourgender,2-Other-Whatisyourgender",
+        "question": "What is your gender?"
       },
       {
         "answer": "P2TCPIPAnswer",


### PR DESCRIPTION
...that post-processing script handles these OK

Addresses #206 by making multiple checked checkboxes only return one response, with a comma-separated list of all checked answers, instead of separate response per checked answer.

@adrifelt for Javascript part
@meacer for Python

