### PR TITLE
Improve text wrapping & tone of the setup survey

### DIFF
--- a/extension/surveys/setup.html
+++ b/extension/surveys/setup.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>Survey setup</title>
+<title>Enroll</title>
 <link rel="stylesheet" type="text/css" href="survey-style.css">
 <script src="../constants.js"></script>
 <script src="survey-generator.js"></script>
@@ -12,15 +12,14 @@
 
 <body>
   <div class="centered inner-centering">
-    <h1>Chrome User Experience Surveys: Setup</h1>
+    <h2>Join Chrome's survey program</h2>
   </div>
 
-  <div class="centered inner-centering alert hidden" id="explanation">
-    <b>Please help us make sure we reach the broadest possible set of
-    Chrome users by answering the following questions. We would
-    greatly appreciate your responses.</b>
-    <br>
-    We will not use this information to identify you personally.
+  <div class="centered inner-centering alert-gentle hidden" id="explanation">
+      <b>What kind of Chrome user are you?</b>
+      <br />
+      We want to make sure we hear feedback from all kinds of people. We won't
+      use this information to identify you personally. Thank you!
   </div>
 
   <div class="centered inner-centering alert hidden" id="already-submitted">


### PR DESCRIPTION
This makes the setup survey look friendlier by softening the tone and decreasing the reading level of the initial text. Fixes #211

Screenshot:
![screen shot 2015-04-28 at 5 48 33 pm](https://cloud.githubusercontent.com/assets/4962198/7383144/e2828cde-edce-11e4-90ca-63a701092629.png)
