### PR TITLE
Horizontally center the example image for surveys

### DIFF
--- a/extension/surveys/setup.html
+++ b/extension/surveys/setup.html
@@ -15,11 +15,12 @@
     <h2>Join Chrome's survey program</h2>
   </div>
 
-  <div class="centered inner-centering alert-gentle hidden" id="explanation">
-      <b>What kind of Chrome user are you?</b>
-      <br />
-      We want to make sure we hear feedback from all kinds of people. We won't
-      use this information to identify you personally. Thank you!
+  <div class="centered inner-centering alert-gentle hidden explanation-text"
+      id="explanation">
+    <b>What kind of Chrome user are you?</b>
+    <br />
+    We want to make sure we hear feedback from all kinds of people. We won't
+    use this information to identify you personally. Thank you!
   </div>
 
   <div class="centered inner-centering alert hidden" id="already-completed">

--- a/extension/surveys/survey-style.css
+++ b/extension/surveys/survey-style.css
@@ -47,12 +47,19 @@
 }
 
 .example {
-  padding-top: 20px;
+  position: relative;
+  vertical-align: middle;
 }
 
-#explanation {
+.explanation-text {
   max-width: 600px;
   padding-bottom: 20px;
+}
+
+.explanation-img {
+  line-height: 220px;
+  height: 220px;
+  max-width: 600px;
 }
 
 .fieldset {

--- a/extension/surveys/survey.html
+++ b/extension/surveys/survey.html
@@ -12,7 +12,8 @@
 
 <body>
   <div class="scroll-holder">
-    <div class="centered inner-centering alert hidden" id="explanation">
+    <div class="centered inner-centering alert hidden explanation-img"
+        id="explanation">
       <img class="example" height="200px" id="example-img">
     </div>
 


### PR DESCRIPTION
Images need to be horizontally centered if they are too short to fill the full height of the screenshot area.

![screen shot 2015-04-30 at 8 47 48 am](https://cloud.githubusercontent.com/assets/4962198/7416617/9746e2fe-ef15-11e4-9dfd-d0b9c9c0b83d.png)
Fixes #227 
