### PR TITLE
Record the freeform answers when people choose 'OTHER'

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -604,6 +604,7 @@ chrome.experienceSamplingPrivate.onDecision.addListener(recordEvent);
 function handleCompletedSurvey(message) {
   if (message[constants.MSG_TYPE] !== constants.MSG_SURVEY)
     return;
+  console.log(JSON.stringify(message));
   getParticipantId().then(function(participantId) {
     var record = new SurveySubmission.SurveyRecord(
         message['survey_type'],

--- a/extension/background.js
+++ b/extension/background.js
@@ -604,7 +604,6 @@ chrome.experienceSamplingPrivate.onDecision.addListener(recordEvent);
 function handleCompletedSurvey(message) {
   if (message[constants.MSG_TYPE] !== constants.MSG_SURVEY)
     return;
-  console.log(JSON.stringify(message));
   getParticipantId().then(function(participantId) {
     var record = new SurveySubmission.SurveyRecord(
         message['survey_type'],

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -536,11 +536,11 @@ function addRequiredMarker(parentNode) {
  */
 function getFormValues(questionArr, form) {
   var responses = [];
-  function grabQuestion(question, altDomId) {
+  function grabQuestion(question, alternateDomId) {
     var questionStr =
         question.placeholder || question.question;  // The question text.
     var questionLookup =
-        altDomId || getDomNameFromValue(questionStr);  // Dom ID
+        alternateDomId || getDomNameFromValue(questionStr);  // Dom ID
 
     if (question.questionType === constants.QuestionType.CHECKBOX) {
       // Checkboxes may have multiple answers.
@@ -575,9 +575,9 @@ function getFormValues(questionArr, form) {
     var otherQuestionLookup = getDomNameFromValue(question.question) + '-OTHER';
     if (form[otherQuestionLookup]) {
       var otherSubquestion = new EssayQuestion(
-        constants.QuestionType.SHORT_ESSAY,
-        '[OTHER] ' + question.question,
-        false);
+          constants.QuestionType.SHORT_ESSAY,
+          '[OTHER] ' + question.question,
+          false);
       grabQuestion(otherSubquestion, otherQuestionLookup);
     }
   }

--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -18,14 +18,6 @@ function Question(questionType, question, required) {
 }
 
 /**
- * Set a DOM ID to associate with a Question.
- * @param {string} id The DOM ID of the question in the current DOM.
- */
-Question.prototype.setCurrentDomId = function(id) {
-  this.currentDomId = id;
-};
-
-/**
  * Set a placeholder version of the question. Instead of any URLs or private
  * info that might be in the full question, this version should be PII-free.
  * @param {string} placeholder The placeholder version of the question.
@@ -544,10 +536,11 @@ function addRequiredMarker(parentNode) {
  */
 function getFormValues(questionArr, form) {
   var responses = [];
-  function grabQuestion(question) {
+  function grabQuestion(question, altDomId) {
     var questionStr =
         question.placeholder || question.question;  // The question text.
-    var questionLookup = question.currentDomId || getDomNameFromValue(questionStr);  // Dom ID
+    var questionLookup =
+        altDomId || getDomNameFromValue(questionStr);  // Dom ID
 
     if (question.questionType === constants.QuestionType.CHECKBOX) {
       // Checkboxes may have multiple answers.
@@ -585,8 +578,7 @@ function getFormValues(questionArr, form) {
         constants.QuestionType.SHORT_ESSAY,
         '[OTHER] ' + question.question,
         false);
-      otherSubquestion.setCurrentDomId(otherQuestionLookup);
-      grabQuestion(otherSubquestion);
+      grabQuestion(otherSubquestion, otherQuestionLookup);
     }
   }
   for (var i = 0; i < questionArr.length; i++) {


### PR DESCRIPTION
Some checkbox and radio questions have an 'OTHER' response that accepts a short freeform answer. Previously the freeform response was not being recorded. This adds the freeform response.

The 'OTHER' response will be recorded as a separate question, prefixed by "[OTHER]". It will always be present in the response, either with 'NOANSWER' or the value.

Fixes #222 
