### PR TITLE
Improve horizontal scale handling

### DIFF
--- a/extension/surveys/survey-generator.js
+++ b/extension/surveys/survey-generator.js
@@ -268,8 +268,6 @@ ScaleQuestion.prototype.setAttributes = function(attributes) {
 ScaleQuestion.prototype.makeSingleRow =
     function(horizontal, questionName, reverse, showLabels) {
   var container = document.createElement('div');
-  if (horizontal)
-    container.classList.add('horizontal-scale-container')
   var reversedScale = reverse ?
       flipArray(this.scale, this.randomize) :
       this.scale;
@@ -292,16 +290,8 @@ ScaleQuestion.prototype.makeSingleRow =
     label.setAttribute('for', shrunkenAnswer);
     label.textContent = reversedScale[i];
 
-    if (horizontal) {
-      if (showLabels) {
-        answer.appendChild(label);
-        answer.appendChild(document.createElement('br'));
-      }
-      answer.appendChild(radio);
-    } else {
-      answer.appendChild(radio);
-      answer.appendChild(label);
-    }
+    answer.appendChild(radio);
+    answer.appendChild(label);
     container.appendChild(answer);
   }
 
@@ -339,27 +329,35 @@ ScaleQuestion.prototype.makeDOMTree = function() {
     addRequiredMarker(legend);
   container.appendChild(legend);
 
+  var responseContainer = document.createElement('div');
+  if (horizontal)
+    responseContainer.classList.add('horizontal-scale-container');
+
   var reverse = this.randomize == constants.Randomize.NONE ? false : coinToss();
   var shrunkenQuestion = getDomNameFromValue(this.placeholder || this.question);
   if (multi) {
     var shuffledAttributes =
         knuthShuffle(this.attributes, constants.Randomize.ALL);
     for (var i = 0; i < shuffledAttributes.length; i++) {
+      var row = document.createElement('div');
       var floatScale = document.createElement('div');
-      floatScale.classList.add('horizontal-rowlabel');
-      if (i == 0)
-        floatScale.classList.add('first-rowlabel');
+      if (horizontal) {
+        floatScale.classList.add('horizontal-rowlabel');
+        row.classList.add('horizontal-scale-row');
+      }
       floatScale.textContent = shuffledAttributes[i] + ':';
-      container.appendChild(floatScale);
+      row.appendChild(floatScale);
       var questionName =
           getDomNameFromValue(shuffledAttributes[i]) + shrunkenQuestion;
-      container.appendChild(
+      row.appendChild(
           this.makeSingleRow(horizontal, questionName, reverse, (i == 0)));
+      responseContainer.appendChild(row);
     }
   } else {
-    container.appendChild(
+    responseContainer.appendChild(
         this.makeSingleRow(horizontal, shrunkenQuestion, reverse, true));
   }
+  container.appendChild(responseContainer);
   return container;
 };
 

--- a/extension/surveys/survey-style.css
+++ b/extension/surveys/survey-style.css
@@ -65,6 +65,7 @@
 .fieldset {
   background-color: #ECF3FE;
   border: none;
+  overflow-x: auto;
   margin-bottom: 1em;
   padding-bottom: 8px;
   padding-left: 3%;
@@ -89,7 +90,7 @@ h2.scroll-heading {
 }
 
 .horizontal-rowlabel {
-  float: left;
+  display: table-cell;
   font-family: 'OpenSansSemibold';
   padding-bottom: 5px;
   padding-right: 20px;
@@ -97,15 +98,20 @@ h2.scroll-heading {
 }
 
 .horizontal-scale {
-  float: left;
-  font-size: .75em;
+  display: table-cell;
+  font-size: .7em;
   padding-bottom: 5px;
+  padding-right: 20px;
   text-align: center;
-  width: 130px;
+  white-space: nowrap;
 }
 
 .horizontal-scale-container {
-  min-width: 900px;
+  display: table;
+}
+
+.horizontal-scale-row {
+  display: table-row;
 }
 
 html, body {

--- a/extension/surveys/survey-style.css
+++ b/extension/surveys/survey-style.css
@@ -65,8 +65,8 @@
 .fieldset {
   background-color: #ECF3FE;
   border: none;
-  overflow-x: auto;
   margin-bottom: 1em;
+  overflow-x: auto;
   padding-bottom: 8px;
   padding-left: 3%;
   padding-right: 3%;


### PR DESCRIPTION
The horizontal scales have been a nightmare. They're too wide to fit in on a laptop-size window, hence bugs like #262. This PR takes a stab at fixing this. Changes:
1. The labels are now directly next to the radio buttons, like the Berkeley study. This makes it easier to see which radio option lines up with which answer.
2. That specific question scrolls, instead of making the entire survey scrollable.
3. The blue extends to the full width of the horizontal scale options.

In the average case, I think this is an improvement:
![screen shot 2015-05-08 at 6 02 24 pm](https://cloud.githubusercontent.com/assets/4962198/7547965/a6a778aa-f5ad-11e4-9abc-8afae76e9d4b.png)
![screen shot 2015-05-08 at 6 02 15 pm](https://cloud.githubusercontent.com/assets/4962198/7547969/ae9ed846-f5ad-11e4-91e2-acde10651d0a.png)

However, if your screen is just the right size, you might not notice that there are more survey responses to the right:
![screen shot 2015-05-08 at 6 05 09 pm](https://cloud.githubusercontent.com/assets/4962198/7547971/bf3be5f4-f5ad-11e4-97b9-f357311a28d7.png)

I don't know if there is a really great solution here besides shortening the responses. E.g., "How well do you understand each of these? Very well / OK / Not at all".
