### PR TITLE
Squash multiple consent windows

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -15,7 +15,7 @@
 var cesp = cesp || {};
 
 cesp.openTabId = -1;
-cesp.openConsentId = -1;
+cesp.openConsentTabId = -1;
 
 // Settings.
 cesp.NOTIFICATION_TITLE = 'Take a Chrome user experience survey!';
@@ -172,7 +172,7 @@ function maybeShowConsentOrSetupSurvey() {
         chrome.tabs.create({
           'url': chrome.extension.getURL('consent.html?os=' + os)
         }, function(tab) {
-          cesp.openConsentId = tab.id;
+          cesp.openConsentTabId = tab.id;
         });
       });
     } else if (lookup[constants.CONSENT_KEY] === constants.CONSENT_REJECTED) {
@@ -421,9 +421,9 @@ function showSurveyNotification(element, decision) {
               'url': chrome.extension.getURL('consent.html')
             }, function(tab) {
               try {
-                chrome.tabs.remove(cesp.openConsentId);
+                chrome.tabs.remove(cesp.openConsentTabId);
               } catch (err) { }
-              cesp.openConsentId = tab.id;
+              cesp.openConsentTabId = tab.id;
             });
           };
           loadSurvey(element, decision, timePromptShown, timePromptClicked)

--- a/extension/background.js
+++ b/extension/background.js
@@ -15,6 +15,7 @@
 var cesp = cesp || {};
 
 cesp.openTabId = -1;
+cesp.openConsentId = -1;
 
 // Settings.
 cesp.NOTIFICATION_TITLE = 'Take a Chrome user experience survey!';
@@ -168,8 +169,11 @@ function maybeShowConsentOrSetupSurvey() {
     if (!lookup || !lookup[constants.CONSENT_KEY] ||
         lookup[constants.CONSENT_KEY] === constants.CONSENT_PENDING) {
       getOperatingSystem().then(function(os) {
-        chrome.tabs.create(
-            {'url': chrome.extension.getURL('consent.html?os=' + os)});
+        chrome.tabs.create({
+          'url': chrome.extension.getURL('consent.html?os=' + os)
+        }, function(tab) {
+          cesp.openConsentId = tab.id;
+        });
       });
     } else if (lookup[constants.CONSENT_KEY] === constants.CONSENT_REJECTED) {
       chrome.management.uninstallSelf();
@@ -415,6 +419,11 @@ function showSurveyNotification(element, decision) {
             if (buttonIndex != 1) return;
             chrome.tabs.create({
               'url': chrome.extension.getURL('consent.html')
+            }, function(tab) {
+              try {
+                chrome.tabs.remove(cesp.openConsentId);
+              } catch (err) { }
+              cesp.openConsentId = tab.id;
             });
           };
           loadSurvey(element, decision, timePromptShown, timePromptClicked)


### PR DESCRIPTION
Record the current desired consent window, and squash all others that Chrome tries to helpfully "restore."

I need to file a bug over this Chrome window behavior, it's pretty unfortunate...

Fixes #230 
